### PR TITLE
Add reports support in administrative ui

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -9,9 +9,9 @@
         <img
           src="/logo-removebg-preview.png"
           alt="Plus Icon"
-          class="w-9 h-9 mr-2"
+          class="w-9 h-9"
         >
-        Social Service System Plus
+        SSP+
       </NuxtLink>
     </div>
 
@@ -20,14 +20,14 @@
       <ul class="menu menu-horizontal space-x-1">
         <!-- Links for user scope (administrativo) -->
         <template v-if="scope === 'user'">
-          <li>
+          <!-- <li>
             <NuxtLink
               to="/administrativo"
               class="btn-ghost"
             >
               Administrativo
             </NuxtLink>
-          </li>
+          </li> -->
           <li>
             <NuxtLink
               to="/administrativo/alumnos"

--- a/components/organisms/ComissionOfficesTable.vue
+++ b/components/organisms/ComissionOfficesTable.vue
@@ -10,7 +10,7 @@
             v-if="showStudent"
             class="text-left"
           >
-            Estudiante
+            Alumno
           </th>
           <th
             v-if="showVacancy"
@@ -70,18 +70,28 @@
             v-if="showStudent"
             class="text-left"
           >
-            {{ comissionOffice.student?.name || 'N/A' }}
+            <NuxtLink
+              v-if="comissionOffice.student"
+              :to="`/administrativo/alumnos/${comissionOffice.student.id}`"
+              class="link link-hover"
+            >
+              {{ comissionOffice.student.name }}
+            </NuxtLink>
+            <span v-else>N/A</span>
           </td>
           <td
             v-if="showVacancy"
             class="text-left"
           >
-            <div
-              class="max-w-xs whitespace-wrap"
-              :title="comissionOffice.vacancy?.name"
+            <NuxtLink
+              v-if="comissionOffice.vacancy"
+              :to="`/administrativo/plazas/${comissionOffice.vacancy.id}`"
+              class="link link-hover max-w-xs whitespace-wrap"
+              :title="comissionOffice.vacancy.name"
             >
-              {{ comissionOffice.vacancy?.name || 'N/A' }}
-            </div>
+              {{ comissionOffice.vacancy.name }}
+            </NuxtLink>
+            <span v-else>N/A</span>
           </td>
           <td
             v-if="showCycle"
@@ -131,14 +141,6 @@
               >
                 <AtomsIconMicroXMark />
               </button>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs btn-circle text-error hover:bg-error hover:text-error-content"
-                :title="`Eliminar oficio de comisión ${comissionOffice.id}`"
-                @click="handleDeleteClick(comissionOffice.id, $event)"
-              >
-                <AtomsIconMicroTrash />
-              </button>
             </div>
           </td>
         </tr>
@@ -155,44 +157,6 @@
       </p>
     </div>
   </div>
-
-  <!-- Delete Confirmation Modal -->
-  <ModalComponent
-    v-model="deleteModal"
-    modal-class="w-fit"
-  >
-    <div class="flex flex-col gap-4 w-80">
-      <h2 class="text-lg font-semibold mb-2 text-error">
-        Confirmar eliminación
-      </h2>
-      <div class="flex items-center gap-3 p-4 bg-error/10 rounded-lg">
-        <AtomsIconOutlinedError class="w-6 h-6 text-error flex-shrink-0" />
-        <p class="text-sm">
-          ¿Está seguro de que desea eliminar el oficio de comisión <strong>#{{ selectedComissionOfficeId }}</strong>?
-        </p>
-      </div>
-      <p class="text-xs text-base-content/60">
-        Esta acción no se puede deshacer.
-      </p>
-      <div class="flex gap-2 justify-end">
-        <button
-          type="button"
-          class="btn btn-ghost"
-          @click="cancelDelete"
-        >
-          Cancelar
-        </button>
-        <button
-          type="button"
-          class="btn btn-error"
-          @click="confirmDelete"
-        >
-          <AtomsIconMicroTrash />
-          Eliminar
-        </button>
-      </div>
-    </div>
-  </ModalComponent>
 
   <!-- Approve Confirmation Modal -->
   <ModalComponent
@@ -287,7 +251,6 @@ interface ComissionOfficesTableProps {
 interface ComissionOfficesTableEmits {
   'update:order': [value: string]
   'row-click': [id: number, ctrlPressed: boolean]
-  'row-delete': [id: number]
   'row-approve': [id: number]
   'row-reject': [id: number]
 }
@@ -302,8 +265,6 @@ const props = withDefaults(defineProps<ComissionOfficesTableProps>(), {
 
 const emit = defineEmits<ComissionOfficesTableEmits>()
 
-// Modal states
-const deleteModal = ref(false)
 const approveModal = ref(false)
 const rejectModal = ref(false)
 const selectedComissionOfficeId = ref<number | null>(null)
@@ -319,12 +280,6 @@ const handleRowClick = (id: number, event: MouseEvent) => {
   emit('row-click', id, ctrlPressed)
 }
 
-const handleDeleteClick = (id: number, event: MouseEvent) => {
-  event.stopPropagation()
-  selectedComissionOfficeId.value = id
-  deleteModal.value = true
-}
-
 const handleApproveClick = (id: number, event: MouseEvent) => {
   event.stopPropagation()
   selectedComissionOfficeId.value = id
@@ -335,21 +290,6 @@ const handleRejectClick = (id: number, event: MouseEvent) => {
   event.stopPropagation()
   selectedComissionOfficeId.value = id
   rejectModal.value = true
-}
-
-const cancelDelete = () => {
-  console.log('cancelDelete', selectedComissionOfficeId.value)
-  deleteModal.value = false
-  selectedComissionOfficeId.value = null
-}
-
-const confirmDelete = () => {
-  console.log('confirmDelete', selectedComissionOfficeId.value)
-  if (selectedComissionOfficeId.value !== null) {
-    emit('row-delete', selectedComissionOfficeId.value)
-    deleteModal.value = false
-    selectedComissionOfficeId.value = null
-  }
 }
 
 const cancelApprove = () => {

--- a/components/organisms/FinalReportsTable.vue
+++ b/components/organisms/FinalReportsTable.vue
@@ -1,0 +1,348 @@
+<template>
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th class="text-left">
+            ID
+          </th>
+          <th
+            v-if="showStudent"
+            class="text-left"
+          >
+            Alumno
+          </th>
+          <th
+            v-if="showVacancy"
+            class="text-left"
+          >
+            Plaza
+          </th>
+          <th
+            v-if="showCycle"
+            class="text-left"
+          >
+            Ciclo
+          </th>
+          <th class="text-left">
+            Horas
+          </th>
+          <th class="text-center">
+            Estado
+          </th>
+          <th class="text-right">
+            <div class="flex items-center justify-end gap-1">
+              Fecha de Creación
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-circle"
+                @click="toggleOrder"
+              >
+                <AtomsIconMicroChevronDown v-if="order === '-FinalReports.createdAt'" />
+                <AtomsIconMicroChevronUp v-else />
+              </button>
+            </div>
+          </th>
+          <th class="text-right">
+            Última Actualización
+          </th>
+          <th class="text-center">
+            Acciones
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="finalReport in finalReports"
+          :key="finalReport.id"
+          class="hover:bg-base-300 table-row cursor-pointer"
+          role="link"
+          tabindex="0"
+          :title="`Ver detalles del reporte final ${finalReport.id}`"
+          @click="handleRowClick(finalReport.id, $event)"
+        >
+          <td class="text-left">
+            <div class="badge badge-outline">
+              {{ finalReport.id }}
+            </div>
+          </td>
+          <td
+            v-if="showStudent"
+            class="text-left"
+          >
+            <NuxtLink
+              v-if="finalReport.student"
+              :to="`/administrativo/alumnos/${finalReport.student.id}`"
+              class="link link-hover"
+            >
+              {{ finalReport.student.name }}
+            </NuxtLink>
+            <span v-else>N/A</span>
+          </td>
+          <td
+            v-if="showVacancy"
+            class="text-left"
+          >
+            <NuxtLink
+              v-if="finalReport.vacancy"
+              :to="`/administrativo/plazas/${finalReport.vacancy.id}`"
+              class="link link-hover max-w-xs whitespace-wrap"
+              :title="finalReport.vacancy.name"
+            >
+              {{ finalReport.vacancy.name }}
+            </NuxtLink>
+            <span v-else>N/A</span>
+          </td>
+          <td
+            v-if="showCycle"
+            class="text-left"
+          >
+            <div
+              class="badge"
+              :class="{ 'badge-primary': finalReport.cycle?.isCurrent }"
+            >
+              {{ finalReport.cycle?.slug || 'N/A' }}
+            </div>
+          </td>
+          <td class="text-left">
+            <div class="badge badge-info">
+              {{ finalReport.hours }}h
+            </div>
+          </td>
+          <td class="text-center">
+            <div
+              class="badge"
+              :class="getStatusBadgeClass(finalReport.status)"
+            >
+              {{ getStatusLabel(finalReport.status) }}
+            </div>
+          </td>
+          <td class="text-right">
+            {{ formatDate(new Date(finalReport.createdAt)) }}
+          </td>
+          <td class="text-right">
+            {{ formatDate(new Date(finalReport.updatedAt)) }}
+          </td>
+          <td class="text-center">
+            <div class="flex gap-1 justify-center">
+              <button
+                type="button"
+                class="btn btn-outline btn-xs btn-circle text-success hover:bg-success hover:text-success-content"
+                :disabled="finalReport.status !== 'PENDING'"
+                :title="`Aprobar reporte final ${finalReport.id}`"
+                @click="handleApproveClick(finalReport.id, $event)"
+              >
+                <AtomsIconMicroCheck />
+              </button>
+              <button
+                type="button"
+                class="btn btn-outline btn-xs btn-circle text-warning hover:bg-warning hover:text-warning-content"
+                :disabled="finalReport.status !== 'PENDING'"
+                :title="`Rechazar reporte final ${finalReport.id}`"
+                @click="handleRejectClick(finalReport.id, $event)"
+              >
+                <AtomsIconMicroXMark />
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Empty state -->
+    <div
+      v-if="finalReports.length === 0"
+      class="text-center py-8"
+    >
+      <p class="text-gray-500">
+        {{ emptyMessage || 'No se encontraron reportes finales.' }}
+      </p>
+    </div>
+  </div>
+
+  <!-- Approve Confirmation Modal -->
+  <ModalComponent
+    v-model="approveModal"
+    modal-class="w-fit"
+  >
+    <div class="flex flex-col gap-4 w-80">
+      <h2 class="text-lg font-semibold mb-2 text-success">
+        Confirmar aprobación
+      </h2>
+      <div class="flex items-center gap-3 p-4 bg-success/10 rounded-lg">
+        <AtomsIconMicroCheck class="w-6 h-6 text-success flex-shrink-0" />
+        <p class="text-sm">
+          ¿Está seguro de que desea aprobar el reporte final <strong>#{{ selectedFinalReportId }}</strong>?
+        </p>
+      </div>
+      <p class="text-xs text-base-content/60">
+        Esta acción cambiará el estado del reporte a "Aprobado".
+      </p>
+      <div class="flex gap-2 justify-end">
+        <button
+          type="button"
+          class="btn btn-ghost"
+          @click="cancelApprove"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          class="btn btn-success"
+          @click="confirmApprove"
+        >
+          <AtomsIconMicroCheck />
+          Aprobar
+        </button>
+      </div>
+    </div>
+  </ModalComponent>
+
+  <!-- Reject Confirmation Modal -->
+  <ModalComponent
+    v-model="rejectModal"
+    modal-class="w-fit"
+  >
+    <div class="flex flex-col gap-4 w-80">
+      <h2 class="text-lg font-semibold mb-2 text-warning">
+        Confirmar rechazo
+      </h2>
+      <div class="flex items-center gap-3 p-4 bg-warning/10 rounded-lg">
+        <AtomsIconMicroXMark class="w-6 h-6 text-warning flex-shrink-0" />
+        <p class="text-sm">
+          ¿Está seguro de que desea rechazar el reporte final <strong>#{{ selectedFinalReportId }}</strong>?
+        </p>
+      </div>
+      <p class="text-xs text-base-content/60">
+        Esta acción cambiará el estado del reporte a "Rechazado".
+      </p>
+      <div class="flex gap-2 justify-end">
+        <button
+          type="button"
+          class="btn btn-ghost"
+          @click="cancelReject"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          class="btn btn-warning"
+          @click="confirmReject"
+        >
+          <AtomsIconMicroXMark />
+          Rechazar
+        </button>
+      </div>
+    </div>
+  </ModalComponent>
+</template>
+
+<script setup lang="ts">
+import { formatDate } from '~/common/dates'
+import type { FinalReportWithRelations } from '~/types/api/final-reports'
+
+interface FinalReportsTableProps {
+  finalReports: FinalReportWithRelations[]
+  order?: string
+  emptyMessage?: string
+  showStudent?: boolean
+  showVacancy?: boolean
+  showCycle?: boolean
+}
+
+interface FinalReportsTableEmits {
+  'update:order': [value: string]
+  'row-click': [id: number, ctrlPressed: boolean]
+  'row-approve': [id: number]
+  'row-reject': [id: number]
+}
+
+const props = withDefaults(defineProps<FinalReportsTableProps>(), {
+  order: '-FinalReports.createdAt',
+  emptyMessage: undefined,
+  showStudent: true,
+  showVacancy: true,
+  showCycle: true
+})
+
+const emit = defineEmits<FinalReportsTableEmits>()
+
+const approveModal = ref(false)
+const rejectModal = ref(false)
+const selectedFinalReportId = ref<number | null>(null)
+
+const toggleOrder = () => {
+  const newOrder = props.order === '-FinalReports.createdAt' ? 'FinalReports.createdAt' : '-FinalReports.createdAt'
+  emit('update:order', newOrder)
+}
+
+const handleRowClick = (id: number, event: MouseEvent) => {
+  event.stopPropagation()
+  const ctrlPressed = event.ctrlKey || event.metaKey // metaKey for Mac Cmd key
+  emit('row-click', id, ctrlPressed)
+}
+
+const handleApproveClick = (id: number, event: MouseEvent) => {
+  event.stopPropagation()
+  selectedFinalReportId.value = id
+  approveModal.value = true
+}
+
+const handleRejectClick = (id: number, event: MouseEvent) => {
+  event.stopPropagation()
+  selectedFinalReportId.value = id
+  rejectModal.value = true
+}
+
+const cancelApprove = () => {
+  approveModal.value = false
+  selectedFinalReportId.value = null
+}
+
+const confirmApprove = () => {
+  if (selectedFinalReportId.value !== null) {
+    emit('row-approve', selectedFinalReportId.value)
+    approveModal.value = false
+    selectedFinalReportId.value = null
+  }
+}
+
+const cancelReject = () => {
+  rejectModal.value = false
+  selectedFinalReportId.value = null
+}
+
+const confirmReject = () => {
+  if (selectedFinalReportId.value !== null) {
+    emit('row-reject', selectedFinalReportId.value)
+    rejectModal.value = false
+    selectedFinalReportId.value = null
+  }
+}
+
+const getStatusBadgeClass = (status: string) => {
+  switch (status) {
+    case 'APPROVED':
+      return 'badge-success'
+    case 'REJECTED':
+      return 'badge-error'
+    case 'PENDING':
+      return 'badge-warning'
+    default:
+      return 'badge-ghost'
+  }
+}
+
+const getStatusLabel = (status: string) => {
+  switch (status) {
+    case 'APPROVED':
+      return 'Aprobado'
+    case 'REJECTED':
+      return 'Rechazado'
+    case 'PENDING':
+      return 'Pendiente'
+    default:
+      return status
+  }
+}
+</script>

--- a/components/organisms/ReportsTable.vue
+++ b/components/organisms/ReportsTable.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th class="text-left">
+            ID
+          </th>
+          <th
+            v-if="showStudent"
+            class="text-left"
+          >
+            Alumno
+          </th>
+          <th
+            v-if="showVacancy"
+            class="text-left"
+          >
+            Plaza
+          </th>
+          <th
+            v-if="showCycle"
+            class="text-left"
+          >
+            Ciclo
+          </th>
+          <th class="text-center">
+            Reporte
+          </th>
+          <th class="text-left">
+            Horas
+          </th>
+          <th class="text-center">
+            Estado
+          </th>
+          <th class="text-right">
+            <div class="flex items-center justify-end gap-1">
+              Fecha de Creación
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-circle"
+                @click="toggleOrder"
+              >
+                <AtomsIconMicroChevronDown v-if="order === '-Reports.createdAt'" />
+                <AtomsIconMicroChevronUp v-else />
+              </button>
+            </div>
+          </th>
+          <th class="text-right">
+            Última Actualización
+          </th>
+          <th class="text-center">
+            Acciones
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="report in reports"
+          :key="report.id"
+          class="hover:bg-base-300 table-row cursor-pointer"
+          role="link"
+          tabindex="0"
+          :title="`Ver detalles del reporte ${report.id}`"
+          @click="handleRowClick(report.id, $event)"
+        >
+          <td class="text-left">
+            <div class="badge badge-outline">
+              {{ report.id }}
+            </div>
+          </td>
+          <td
+            v-if="showStudent"
+            class="text-left"
+          >
+            <NuxtLink
+              v-if="report.student"
+              :to="`/administrativo/alumnos/${report.student.id}`"
+              class="link link-hover"
+            >
+              {{ report.student.name }}
+            </NuxtLink>
+            <span v-else>N/A</span>
+          </td>
+          <td
+            v-if="showVacancy"
+            class="text-left"
+          >
+            <NuxtLink
+              v-if="report.vacancy"
+              :to="`/administrativo/plazas/${report.vacancy.id}`"
+              class="link link-hover max-w-xs whitespace-wrap"
+              :title="report.vacancy.name"
+            >
+              {{ report.vacancy.name }}
+            </NuxtLink>
+            <span v-else>N/A</span>
+          </td>
+          <td
+            v-if="showCycle"
+            class="text-left"
+          >
+            <div
+              class="badge"
+              :class="{ 'badge-primary': report.cycle?.isCurrent }"
+            >
+              {{ report.cycle?.slug || 'N/A' }}
+            </div>
+          </td>
+          <td class="text-center">
+            <div class="badge badge-secondary badge-outline">
+              {{ report.reportNumber }}
+            </div>
+          </td>
+          <td class="text-left">
+            <div class="badge badge-info">
+              {{ report.hours }}h
+            </div>
+          </td>
+          <td class="text-center">
+            <div
+              class="badge"
+              :class="getStatusBadgeClass(report.status)"
+            >
+              {{ getStatusLabel(report.status) }}
+            </div>
+          </td>
+          <td class="text-right">
+            {{ formatDate(new Date(report.createdAt)) }}
+          </td>
+          <td class="text-right">
+            {{ formatDate(new Date(report.updatedAt)) }}
+          </td>
+          <td class="text-center">
+            <div class="flex gap-1 justify-center">
+              <button
+                type="button"
+                class="btn btn-outline btn-xs btn-circle text-success hover:bg-success hover:text-success-content"
+                :disabled="report.status !== 'PENDING'"
+                :title="`Aprobar reporte ${report.id}`"
+                @click="handleApproveClick(report.id, $event)"
+              >
+                <AtomsIconMicroCheck />
+              </button>
+              <button
+                type="button"
+                class="btn btn-outline btn-xs btn-circle text-warning hover:bg-warning hover:text-warning-content"
+                :disabled="report.status !== 'PENDING'"
+                :title="`Rechazar reporte ${report.id}`"
+                @click="handleRejectClick(report.id, $event)"
+              >
+                <AtomsIconMicroXMark />
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- Empty state -->
+    <div
+      v-if="reports.length === 0"
+      class="text-center py-8"
+    >
+      <p class="text-gray-500">
+        {{ emptyMessage || 'No se encontraron reportes.' }}
+      </p>
+    </div>
+  </div>
+
+  <!-- Approve Confirmation Modal -->
+  <ModalComponent
+    v-model="approveModal"
+    modal-class="w-fit"
+  >
+    <div class="flex flex-col gap-4 w-80">
+      <h2 class="text-lg font-semibold mb-2 text-success">
+        Confirmar aprobación
+      </h2>
+      <div class="flex items-center gap-3 p-4 bg-success/10 rounded-lg">
+        <AtomsIconMicroCheck class="w-6 h-6 text-success flex-shrink-0" />
+        <p class="text-sm">
+          ¿Está seguro de que desea aprobar el reporte <strong>#{{ selectedReportId }}</strong>?
+        </p>
+      </div>
+      <p class="text-xs text-base-content/60">
+        Esta acción cambiará el estado del reporte a "Aprobado".
+      </p>
+      <div class="flex gap-2 justify-end">
+        <button
+          type="button"
+          class="btn btn-ghost"
+          @click="cancelApprove"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          class="btn btn-success"
+          @click="confirmApprove"
+        >
+          <AtomsIconMicroCheck />
+          Aprobar
+        </button>
+      </div>
+    </div>
+  </ModalComponent>
+
+  <!-- Reject Confirmation Modal -->
+  <ModalComponent
+    v-model="rejectModal"
+    modal-class="w-fit"
+  >
+    <div class="flex flex-col gap-4 w-80">
+      <h2 class="text-lg font-semibold mb-2 text-warning">
+        Confirmar rechazo
+      </h2>
+      <div class="flex items-center gap-3 p-4 bg-warning/10 rounded-lg">
+        <AtomsIconMicroXMark class="w-6 h-6 text-warning flex-shrink-0" />
+        <p class="text-sm">
+          ¿Está seguro de que desea rechazar el reporte <strong>#{{ selectedReportId }}</strong>?
+        </p>
+      </div>
+      <p class="text-xs text-base-content/60">
+        Esta acción cambiará el estado del reporte a "Rechazado".
+      </p>
+      <div class="flex gap-2 justify-end">
+        <button
+          type="button"
+          class="btn btn-ghost"
+          @click="cancelReject"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          class="btn btn-warning"
+          @click="confirmReject"
+        >
+          <AtomsIconMicroXMark />
+          Rechazar
+        </button>
+      </div>
+    </div>
+  </ModalComponent>
+</template>
+
+<script setup lang="ts">
+import { formatDate } from '~/common/dates'
+import type { ReportWithRelations } from '~/types/api/report'
+
+interface ReportsTableProps {
+  reports: ReportWithRelations[]
+  order?: string
+  emptyMessage?: string
+  showStudent?: boolean
+  showVacancy?: boolean
+  showCycle?: boolean
+}
+
+interface ReportsTableEmits {
+  'update:order': [value: string]
+  'row-click': [id: number, ctrlPressed: boolean]
+  'row-approve': [id: number]
+  'row-reject': [id: number]
+}
+
+const props = withDefaults(defineProps<ReportsTableProps>(), {
+  order: '-Reports.createdAt',
+  emptyMessage: undefined,
+  showStudent: true,
+  showVacancy: true,
+  showCycle: true
+})
+
+const emit = defineEmits<ReportsTableEmits>()
+
+const approveModal = ref(false)
+const rejectModal = ref(false)
+const selectedReportId = ref<number | null>(null)
+
+const toggleOrder = () => {
+  const newOrder = props.order === '-Reports.createdAt' ? 'Reports.createdAt' : '-Reports.createdAt'
+  emit('update:order', newOrder)
+}
+
+const handleRowClick = (id: number, event: MouseEvent) => {
+  event.stopPropagation()
+  const ctrlPressed = event.ctrlKey || event.metaKey // metaKey for Mac Cmd key
+  emit('row-click', id, ctrlPressed)
+}
+
+const handleApproveClick = (id: number, event: MouseEvent) => {
+  event.stopPropagation()
+  selectedReportId.value = id
+  approveModal.value = true
+}
+
+const handleRejectClick = (id: number, event: MouseEvent) => {
+  event.stopPropagation()
+  selectedReportId.value = id
+  rejectModal.value = true
+}
+
+const cancelApprove = () => {
+  approveModal.value = false
+  selectedReportId.value = null
+}
+
+const confirmApprove = () => {
+  if (selectedReportId.value !== null) {
+    emit('row-approve', selectedReportId.value)
+    approveModal.value = false
+    selectedReportId.value = null
+  }
+}
+
+const cancelReject = () => {
+  rejectModal.value = false
+  selectedReportId.value = null
+}
+
+const confirmReject = () => {
+  if (selectedReportId.value !== null) {
+    emit('row-reject', selectedReportId.value)
+    rejectModal.value = false
+    selectedReportId.value = null
+  }
+}
+
+const getStatusBadgeClass = (status: string) => {
+  switch (status) {
+    case 'APPROVED':
+      return 'badge-success'
+    case 'REJECTED':
+      return 'badge-error'
+    case 'PENDING':
+      return 'badge-warning'
+    default:
+      return 'badge-ghost'
+  }
+}
+
+const getStatusLabel = (status: string) => {
+  switch (status) {
+    case 'APPROVED':
+      return 'Aprobado'
+    case 'REJECTED':
+      return 'Rechazado'
+    case 'PENDING':
+      return 'Pendiente'
+    default:
+      return status
+  }
+}
+</script>

--- a/composables/useActivateStudent.ts
+++ b/composables/useActivateStudent.ts
@@ -1,0 +1,85 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { isAxiosError } from 'axios'
+import type { FastifyError } from '~/types/api/error.d'
+import type { Student } from '~/types/api/student.d'
+import useAxios from '~/composables/useAxios'
+import { useLoginStore } from '~/stores/login'
+import { useNotificationStore } from '~/stores/notification'
+import { keyPrefix as studentKeyPrefix } from '~/composables/useFetchStudent'
+import { key as studentsKey } from '~/composables/useFetchStudents'
+
+export const useActivateStudent = () => {
+  const axios = useAxios()
+  const loginStore = useLoginStore()
+  const notificationStore = useNotificationStore()
+
+  const error: Ref<Error | FastifyError | null> = ref(null)
+  const pending = ref(false)
+  const data: Ref<Student | null> = ref(null)
+
+  const mutate = async (id: string | number): Promise<void> => {
+    try {
+      pending.value = true
+      error.value = null
+      data.value = null
+
+      const response = await axios.patch<Student>(`/students/${id}/activate`, {}, {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
+      })
+
+      data.value = response.data
+
+      // Show success notification
+      notificationStore.add({
+        type: 'success',
+        title: 'Alumno activado',
+        description: 'El alumno ha sido activado exitosamente'
+      })
+
+      // Refresh any cached data related to students
+      refreshNuxtData(studentsKey)
+      refreshNuxtData(studentKeyPrefix + id)
+    } catch (err: unknown) {
+      console.error('Error activating student:', err)
+
+      if (isAxiosError<FastifyError>(err) && err.response) {
+        const messages: Record<string, string> = {
+          'Student not found': 'Alumno no encontrado',
+          'Student is already active': 'El alumno ya está activo'
+        }
+        error.value = err.response.data
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al activar',
+          description: messages[err.response.data.message] ?? 'Error desconocido'
+        })
+      } else if (err instanceof Error) {
+        error.value = err
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al activar',
+          description: 'Error al activar el alumno'
+        })
+      } else {
+        error.value = new Error('Unknown error')
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al activar',
+          description: 'Error desconocido al activar el alumno'
+        })
+      }
+    } finally {
+      pending.value = false
+    }
+  }
+
+  return {
+    error,
+    pending,
+    data,
+    mutate
+  }
+}

--- a/composables/useActivateVacancy.ts
+++ b/composables/useActivateVacancy.ts
@@ -1,0 +1,85 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { isAxiosError } from 'axios'
+import type { FastifyError } from '~/types/api/error.d'
+import type { Vacancy } from '~/types/api/vacancy.d'
+import useAxios from '~/composables/useAxios'
+import { useLoginStore } from '~/stores/login'
+import { useNotificationStore } from '~/stores/notification'
+import { keyPrefix as vacancyKeyPrefix } from '~/composables/useFetchVacancy'
+import { useFetchVacanciesKey } from '~/composables/useFetchVacancies'
+
+export const useActivateVacancy = () => {
+  const axios = useAxios()
+  const loginStore = useLoginStore()
+  const notificationStore = useNotificationStore()
+
+  const error: Ref<Error | FastifyError | null> = ref(null)
+  const pending = ref(false)
+  const data: Ref<Vacancy | null> = ref(null)
+
+  const mutate = async (id: string | number): Promise<void> => {
+    try {
+      pending.value = true
+      error.value = null
+      data.value = null
+
+      const response = await axios.patch<Vacancy>(`/vacancies/${id}/activate`, {}, {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
+      })
+
+      data.value = response.data
+
+      // Show success notification
+      notificationStore.add({
+        type: 'success',
+        title: 'Plaza activada',
+        description: 'La plaza ha sido activada exitosamente'
+      })
+
+      // Refresh any cached data related to vacancies
+      refreshNuxtData(useFetchVacanciesKey)
+      refreshNuxtData(vacancyKeyPrefix + id)
+    } catch (err: unknown) {
+      console.error('Error activating vacancy:', err)
+
+      if (isAxiosError<FastifyError>(err) && err.response) {
+        const messages: Record<string, string> = {
+          'Vacancy not found': 'Plaza no encontrada',
+          'Vacancy is already active': 'La plaza ya está activa'
+        }
+        error.value = err.response.data
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al activar',
+          description: messages[err.response.data.message] ?? 'Error desconocido'
+        })
+      } else if (err instanceof Error) {
+        error.value = err
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al activar',
+          description: 'Error al activar la plaza'
+        })
+      } else {
+        error.value = new Error('Unknown error')
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al activar',
+          description: 'Error desconocido al activar la plaza'
+        })
+      }
+    } finally {
+      pending.value = false
+    }
+  }
+
+  return {
+    error,
+    pending,
+    data,
+    mutate
+  }
+}

--- a/composables/useDeactivateStudent.ts
+++ b/composables/useDeactivateStudent.ts
@@ -1,0 +1,85 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { isAxiosError } from 'axios'
+import type { FastifyError } from '~/types/api/error.d'
+import type { Student } from '~/types/api/student.d'
+import useAxios from '~/composables/useAxios'
+import { useLoginStore } from '~/stores/login'
+import { useNotificationStore } from '~/stores/notification'
+import { keyPrefix as studentKeyPrefix } from '~/composables/useFetchStudent'
+import { key as studentsKey } from '~/composables/useFetchStudents'
+
+export const useDeactivateStudent = () => {
+  const axios = useAxios()
+  const loginStore = useLoginStore()
+  const notificationStore = useNotificationStore()
+
+  const error: Ref<Error | FastifyError | null> = ref(null)
+  const pending = ref(false)
+  const data: Ref<Student | null> = ref(null)
+
+  const mutate = async (id: string | number): Promise<void> => {
+    try {
+      pending.value = true
+      error.value = null
+      data.value = null
+
+      const response = await axios.patch<Student>(`/students/${id}/deactivate`, {}, {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
+      })
+
+      data.value = response.data
+
+      // Show success notification
+      notificationStore.add({
+        type: 'success',
+        title: 'Alumno desactivado',
+        description: 'El alumno ha sido desactivado exitosamente'
+      })
+
+      // Refresh any cached data related to students
+      refreshNuxtData(studentsKey)
+      refreshNuxtData(studentKeyPrefix + id)
+    } catch (err: unknown) {
+      console.error('Error deactivating student:', err)
+
+      if (isAxiosError<FastifyError>(err) && err.response) {
+        const messages: Record<string, string> = {
+          'Student not found': 'Alumno no encontrado',
+          'Student is already deactivated': 'El alumno ya está desactivado'
+        }
+        error.value = err.response.data
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al desactivar',
+          description: messages[err.response.data.message] ?? 'Error desconocido'
+        })
+      } else if (err instanceof Error) {
+        error.value = err
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al desactivar',
+          description: 'Error al desactivar el alumno'
+        })
+      } else {
+        error.value = new Error('Unknown error')
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al desactivar',
+          description: 'Error desconocido al desactivar el alumno'
+        })
+      }
+    } finally {
+      pending.value = false
+    }
+  }
+
+  return {
+    error,
+    pending,
+    data,
+    mutate
+  }
+}

--- a/composables/useDeactivateVacancy.ts
+++ b/composables/useDeactivateVacancy.ts
@@ -1,0 +1,85 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { isAxiosError } from 'axios'
+import type { FastifyError } from '~/types/api/error.d'
+import type { Vacancy } from '~/types/api/vacancy.d'
+import useAxios from '~/composables/useAxios'
+import { useLoginStore } from '~/stores/login'
+import { useNotificationStore } from '~/stores/notification'
+import { keyPrefix as vacancyKeyPrefix } from '~/composables/useFetchVacancy'
+import { useFetchVacanciesKey } from '~/composables/useFetchVacancies'
+
+export const useDeactivateVacancy = () => {
+  const axios = useAxios()
+  const loginStore = useLoginStore()
+  const notificationStore = useNotificationStore()
+
+  const error: Ref<Error | FastifyError | null> = ref(null)
+  const pending = ref(false)
+  const data: Ref<Vacancy | null> = ref(null)
+
+  const mutate = async (id: string | number): Promise<void> => {
+    try {
+      pending.value = true
+      error.value = null
+      data.value = null
+
+      const response = await axios.patch<Vacancy>(`/vacancies/${id}/deactivate`, {}, {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
+      })
+
+      data.value = response.data
+
+      // Show success notification
+      notificationStore.add({
+        type: 'success',
+        title: 'Plaza desactivada',
+        description: 'La plaza ha sido desactivada exitosamente'
+      })
+
+      // Refresh any cached data related to vacancies
+      refreshNuxtData(useFetchVacanciesKey)
+      refreshNuxtData(vacancyKeyPrefix + id)
+    } catch (err: unknown) {
+      console.error('Error deactivating vacancy:', err)
+
+      if (isAxiosError<FastifyError>(err) && err.response) {
+        const messages: Record<string, string> = {
+          'Vacancy not found': 'Plaza no encontrada',
+          'Vacancy is already deactivated': 'La plaza ya está desactivada'
+        }
+        error.value = err.response.data
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al desactivar',
+          description: messages[err.response.data.message] ?? 'Error desconocido'
+        })
+      } else if (err instanceof Error) {
+        error.value = err
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al desactivar',
+          description: 'Error al desactivar la plaza'
+        })
+      } else {
+        error.value = new Error('Unknown error')
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al desactivar',
+          description: 'Error desconocido al desactivar la plaza'
+        })
+      }
+    } finally {
+      pending.value = false
+    }
+  }
+
+  return {
+    error,
+    pending,
+    data,
+    mutate
+  }
+}

--- a/composables/useFetchDepartment.ts
+++ b/composables/useFetchDepartment.ts
@@ -12,7 +12,7 @@ interface UseFetchDepartmentParams {
 const keyPrefix = 'department-'
 
 export function getDepartmentKey(id: string | number) {
-  return `${keyPrefix}-${id}`
+  return `${keyPrefix}${id}`
 }
 
 export const useFetchDepartment = (params: UseFetchDepartmentParams) => {
@@ -28,7 +28,7 @@ export const useFetchDepartment = (params: UseFetchDepartmentParams) => {
     headers: {
       Authorization: `Bearer ${loginStore.token}`
     },
-    key: () => `department-${departmentId.value}`
+    key: () => `${keyPrefix}${departmentId.value}`
   })
 
   const department = computed(() => data.value ?? null)

--- a/composables/useFetchFinalReports.ts
+++ b/composables/useFetchFinalReports.ts
@@ -1,0 +1,73 @@
+import type { MaybeRef } from 'vue'
+import type { H3Error } from 'h3'
+import type { FinalReportWithRelations } from '~/types/api/final-reports.d'
+import { useRuntimeConfig } from '#imports'
+import { useLoginStore } from '~/stores/login'
+import type { FastifyError } from '~/types/api/error.d'
+
+interface UseFetchFinalReportsParams {
+  order?: MaybeRef<string>
+  limit?: MaybeRef<number>
+  offset?: MaybeRef<number>
+  cycleId?: MaybeRef<number | undefined>
+  studentId?: MaybeRef<number | undefined>
+  vacancyId?: MaybeRef<number | undefined>
+  includeStudent?: MaybeRef<boolean>
+  includeVacancy?: MaybeRef<boolean>
+  includeCycle?: MaybeRef<boolean>
+  status?: MaybeRef<'APPROVED' | 'REJECTED' | 'PENDING' | undefined>
+}
+
+interface FetchFinalReportsResponse {
+  total: number
+  records: FinalReportWithRelations[]
+}
+
+export const useFetchFinalReportsKey = 'final-reports-list'
+
+export const useFetchFinalReports = (params: UseFetchFinalReportsParams = {}) => {
+  const config = useRuntimeConfig()
+  const loginStore = useLoginStore()
+
+  const query = computed(() => ({
+    order: unref(params.order) ?? '-FinalReports.createdAt',
+    limit: unref(params.limit) ?? 50,
+    offset: unref(params.offset) ?? 0,
+    cycleId: unref(params.cycleId) ?? undefined,
+    studentId: unref(params.studentId) ?? undefined,
+    vacancyId: unref(params.vacancyId) ?? undefined,
+    status: unref(params.status) ?? undefined,
+    includeStudent: unref(params.includeStudent) ?? false,
+    includeVacancy: unref(params.includeVacancy) ?? false,
+    includeCycle: unref(params.includeCycle) ?? false
+  }))
+
+  const { data, status: fetchStatus, error, refresh, pending } = useFetch<FetchFinalReportsResponse, H3Error<FastifyError>>('/final-reports', {
+    baseURL: config.public.serverHost,
+    headers: {
+      Authorization: `Bearer ${loginStore.token}`
+    },
+    query,
+    key: useFetchFinalReportsKey
+  })
+
+  const finalReports = computed(() => data.value?.records ?? [])
+  const total = computed(() => data.value?.total ?? 0)
+  const pages = computed(() => Math.ceil(total.value / (unref(params.limit) ?? 50)))
+
+  return {
+    // Data
+    data,
+    finalReports,
+    total,
+    pages,
+
+    // State
+    status: fetchStatus,
+    error,
+    pending,
+
+    // Actions
+    refresh
+  }
+}

--- a/composables/useFetchReports.ts
+++ b/composables/useFetchReports.ts
@@ -1,0 +1,75 @@
+import type { MaybeRef } from 'vue'
+import type { H3Error } from 'h3'
+import type { ReportWithRelations } from '~/types/api/report.d'
+import { useRuntimeConfig } from '#imports'
+import { useLoginStore } from '~/stores/login'
+import type { FastifyError } from '~/types/api/error.d'
+
+interface UseFetchReportsParams {
+  order?: MaybeRef<string>
+  limit?: MaybeRef<number>
+  offset?: MaybeRef<number>
+  cycleId?: MaybeRef<number | undefined>
+  studentId?: MaybeRef<number | undefined>
+  vacancyId?: MaybeRef<number | undefined>
+  reportNumber?: MaybeRef<'1' | '2' | undefined>
+  includeStudent?: MaybeRef<boolean>
+  includeVacancy?: MaybeRef<boolean>
+  includeCycle?: MaybeRef<boolean>
+  status?: MaybeRef<'APPROVED' | 'REJECTED' | 'PENDING' | undefined>
+}
+
+interface FetchReportsResponse {
+  total: number
+  records: ReportWithRelations[]
+}
+
+export const useFetchReportsKey = 'reports-list'
+
+export const useFetchReports = (params: UseFetchReportsParams = {}) => {
+  const config = useRuntimeConfig()
+  const loginStore = useLoginStore()
+
+  const query = computed(() => ({
+    order: unref(params.order) ?? '-Reports.createdAt',
+    limit: unref(params.limit) ?? 50,
+    offset: unref(params.offset) ?? 0,
+    cycleId: unref(params.cycleId) ?? undefined,
+    studentId: unref(params.studentId) ?? undefined,
+    vacancyId: unref(params.vacancyId) ?? undefined,
+    reportNumber: unref(params.reportNumber) ?? undefined,
+    status: unref(params.status) ?? undefined,
+    includeStudent: unref(params.includeStudent) ?? false,
+    includeVacancy: unref(params.includeVacancy) ?? false,
+    includeCycle: unref(params.includeCycle) ?? false
+  }))
+
+  const { data, status: fetchStatus, error, refresh, pending } = useFetch<FetchReportsResponse, H3Error<FastifyError>>('/reports', {
+    baseURL: config.public.serverHost,
+    headers: {
+      Authorization: `Bearer ${loginStore.token}`
+    },
+    query,
+    key: useFetchReportsKey
+  })
+
+  const reports = computed(() => data.value?.records ?? [])
+  const total = computed(() => data.value?.total ?? 0)
+  const pages = computed(() => Math.ceil(total.value / (unref(params.limit) ?? 50)))
+
+  return {
+    // Data
+    data,
+    reports,
+    total,
+    pages,
+
+    // State
+    status: fetchStatus,
+    error,
+    pending,
+
+    // Actions
+    refresh
+  }
+}

--- a/composables/useFetchStudent.ts
+++ b/composables/useFetchStudent.ts
@@ -10,6 +10,8 @@ interface UseFetchStudentParams {
   includeCareer?: MaybeRef<boolean>
 }
 
+export const keyPrefix = 'student-'
+
 export const useFetchStudent = (params: UseFetchStudentParams) => {
   const config = useRuntimeConfig()
   const loginStore = useLoginStore()
@@ -29,7 +31,7 @@ export const useFetchStudent = (params: UseFetchStudentParams) => {
       Authorization: `Bearer ${loginStore.token}`
     },
     query,
-    key: computed(() => `student-${unref(id)}`)
+    key: computed(() => `${keyPrefix}${unref(id)}`)
   })
 
   const student = computed(() => data.value)

--- a/composables/useFetchStudents.ts
+++ b/composables/useFetchStudents.ts
@@ -18,6 +18,8 @@ interface FetchStudentsResponse {
   records: StudentWithCareer[]
 }
 
+export const key = 'students-list'
+
 export const useFetchStudents = (params: UseFetchStudentsParams = {}) => {
   const config = useRuntimeConfig()
   const loginStore = useLoginStore()
@@ -44,7 +46,7 @@ export const useFetchStudents = (params: UseFetchStudentsParams = {}) => {
       Authorization: `Bearer ${loginStore.token}`
     },
     query,
-    key: 'students-list'
+    key
   })
 
   const students = computed(() => data.value?.records ?? [])

--- a/composables/useFetchVacancy.ts
+++ b/composables/useFetchVacancy.ts
@@ -11,10 +11,10 @@ interface UseFetchVacancyParams {
   includeDepartment?: MaybeRef<boolean>
 }
 
-const keyPrefix = 'vacancy-'
+export const keyPrefix = 'vacancy-'
 
 export function getVacancyKey(id: string | number) {
-  return `${keyPrefix}-${id}`
+  return `${keyPrefix}${id}`
 }
 
 export const useFetchVacancy = (params: UseFetchVacancyParams) => {
@@ -40,7 +40,7 @@ export const useFetchVacancy = (params: UseFetchVacancyParams) => {
       Authorization: `Bearer ${loginStore.token}`
     },
     query,
-    key: () => `vacancy-${vacancyId.value}`
+    key: () => `${keyPrefix}${vacancyId.value}`
   })
 
   const vacancy = computed(() => data.value ?? null)

--- a/composables/usePatchFinalReport.ts
+++ b/composables/usePatchFinalReport.ts
@@ -1,0 +1,113 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { isAxiosError } from 'axios'
+import type { FastifyError } from '~/types/api/error.d'
+import type { FinalReport, UpdateFinalReport } from '~/types/api/final-reports.d'
+import useAxios from '~/composables/useAxios'
+import { useLoginStore } from '~/stores/login'
+import { useNotificationStore } from '~/stores/notification'
+
+interface PatchFinalReportPayload extends UpdateFinalReport {
+  status?: 'APPROVED' | 'REJECTED' | 'PENDING'
+  hours?: number
+  fileId?: number
+}
+
+export const usePatchFinalReport = () => {
+  const axios = useAxios()
+  const loginStore = useLoginStore()
+  const notificationStore = useNotificationStore()
+
+  const error: Ref<Error | FastifyError | null> = ref(null)
+  const pending = ref(false)
+  const data: Ref<FinalReport | null> = ref(null)
+
+  const mutate = async (id: string | number, payload: PatchFinalReportPayload): Promise<void> => {
+    try {
+      pending.value = true
+      error.value = null
+      data.value = null
+
+      const response = await axios.patch<FinalReport>(`/final-reports/${id}`, payload, {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
+      })
+
+      data.value = response.data
+
+      // Show success notification based on what was updated
+      if (payload.status) {
+        const successMessages = {
+          APPROVED: {
+            title: 'Reporte aprobado',
+            description: 'El reporte final ha sido aprobado exitosamente'
+          },
+          REJECTED: {
+            title: 'Reporte rechazado',
+            description: 'El reporte final ha sido rechazado exitosamente'
+          },
+          PENDING: {
+            title: 'Reporte actualizado',
+            description: 'El reporte final ha sido marcado como pendiente'
+          }
+        }
+
+        notificationStore.add({
+          type: 'success',
+          title: successMessages[payload.status].title,
+          description: successMessages[payload.status].description
+        })
+      } else {
+        notificationStore.add({
+          type: 'success',
+          title: 'Reporte actualizado',
+          description: 'El reporte final ha sido actualizado exitosamente'
+        })
+      }
+
+      // Refresh any cached data related to final reports
+      refreshNuxtData('final-reports-list')
+    } catch (err: unknown) {
+      console.error('Error updating final report:', err)
+
+      if (isAxiosError<FastifyError>(err) && err.response) {
+        const messages: Record<string, string> = {
+          'Final report not found': 'Reporte final no encontrado',
+          'Cannot change status. Only PENDING status can be changed to APPROVED or REJECTED.': 'No se puede cambiar el estado del reporte final. Solo el estado pendiente puede ser cambiado a aprobado o rechazado.',
+          'Invalid hours value': 'Valor de horas inválido',
+          'File not found': 'Archivo no encontrado'
+        }
+        error.value = err.response.data
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al actualizar',
+          description: messages[err.response.data.message] ?? 'Error desconocido'
+        })
+      } else if (err instanceof Error) {
+        error.value = err
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al actualizar',
+          description: 'Error al actualizar el reporte'
+        })
+      } else {
+        error.value = new Error('Unknown error')
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al actualizar',
+          description: 'Error desconocido al actualizar el reporte final'
+        })
+      }
+    } finally {
+      pending.value = false
+    }
+  }
+
+  return {
+    error,
+    pending,
+    data,
+    mutate
+  }
+}

--- a/composables/usePatchReport.ts
+++ b/composables/usePatchReport.ts
@@ -1,0 +1,113 @@
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { isAxiosError } from 'axios'
+import type { FastifyError } from '~/types/api/error.d'
+import type { Report, UpdateReport } from '~/types/api/report.d'
+import useAxios from '~/composables/useAxios'
+import { useLoginStore } from '~/stores/login'
+import { useNotificationStore } from '~/stores/notification'
+
+interface PatchReportPayload extends UpdateReport {
+  status?: 'APPROVED' | 'REJECTED' | 'PENDING'
+  hours?: number
+  fileId?: number
+}
+
+export const usePatchReport = () => {
+  const axios = useAxios()
+  const loginStore = useLoginStore()
+  const notificationStore = useNotificationStore()
+
+  const error: Ref<Error | FastifyError | null> = ref(null)
+  const pending = ref(false)
+  const data: Ref<Report | null> = ref(null)
+
+  const mutate = async (id: string | number, payload: PatchReportPayload): Promise<void> => {
+    try {
+      pending.value = true
+      error.value = null
+      data.value = null
+
+      const response = await axios.patch<Report>(`/reports/${id}`, payload, {
+        headers: {
+          Authorization: `Bearer ${loginStore.token}`
+        }
+      })
+
+      data.value = response.data
+
+      // Show success notification based on what was updated
+      if (payload.status) {
+        const successMessages = {
+          APPROVED: {
+            title: 'Reporte aprobado',
+            description: 'El reporte ha sido aprobado exitosamente'
+          },
+          REJECTED: {
+            title: 'Reporte rechazado',
+            description: 'El reporte ha sido rechazado exitosamente'
+          },
+          PENDING: {
+            title: 'Reporte actualizado',
+            description: 'El reporte ha sido marcado como pendiente'
+          }
+        }
+
+        notificationStore.add({
+          type: 'success',
+          title: successMessages[payload.status].title,
+          description: successMessages[payload.status].description
+        })
+      } else {
+        notificationStore.add({
+          type: 'success',
+          title: 'Reporte actualizado',
+          description: 'El reporte ha sido actualizado exitosamente'
+        })
+      }
+
+      // Refresh any cached data related to reports
+      refreshNuxtData('reports-list')
+    } catch (err: unknown) {
+      console.error('Error updating report:', err)
+
+      if (isAxiosError<FastifyError>(err) && err.response) {
+        const messages: Record<string, string> = {
+          'Report not found': 'Reporte no encontrado',
+          'Cannot change status. Only PENDING status can be changed to APPROVED or REJECTED.': 'No se puede cambiar el estado del reporte. Solo el estado pendiente puede ser cambiado a aprobado o rechazado.',
+          'Invalid hours value': 'Valor de horas inválido',
+          'File not found': 'Archivo no encontrado'
+        }
+        error.value = err.response.data
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al actualizar',
+          description: messages[err.response.data.message] ?? 'Error desconocido'
+        })
+      } else if (err instanceof Error) {
+        error.value = err
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al actualizar',
+          description: 'Error al actualizar el reporte'
+        })
+      } else {
+        error.value = new Error('Unknown error')
+        notificationStore.add({
+          type: 'error',
+          title: 'Error al actualizar',
+          description: 'Error desconocido al actualizar el reporte'
+        })
+      }
+    } finally {
+      pending.value = false
+    }
+  }
+
+  return {
+    error,
+    pending,
+    data,
+    mutate
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "daisyui": "^4.12.22",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vercel": "^48.1.6"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/pages/administrativo/departamentos/[id]/index.vue
+++ b/pages/administrativo/departamentos/[id]/index.vue
@@ -235,7 +235,7 @@
       modal-class="w-fit"
     >
       <OrganismsDepartmentForm
-        v-model="editForm as any"
+        v-model="editForm"
         :pending="editPending"
         title="Editar departamento"
         submit-text="Guardar cambios"

--- a/pages/administrativo/departamentos/[id]/index.vue
+++ b/pages/administrativo/departamentos/[id]/index.vue
@@ -106,14 +106,6 @@
                     <AtomsIconOutlinedInfo />
                     Editar
                   </button>
-                  <button
-                    type="button"
-                    class="btn btn-outline btn-error btn-md btn-wide lg:btn-md"
-                    disabled
-                  >
-                    <AtomsIconOutlinedError />
-                    Eliminar
-                  </button>
                 </div>
               </div>
             </div>

--- a/pages/administrativo/plazas/[id]/[[subpage]].vue
+++ b/pages/administrativo/plazas/[id]/[[subpage]].vue
@@ -111,9 +111,9 @@
                     <div class="text-base shrink-1 grow-1">
                       <div
                         class="badge badge-lg"
-                        :class="data.disabled ? 'badge-ghost' : 'badge-success'"
+                        :class="data.deletedAt ? 'badge-ghost' : 'badge-success'"
                       >
-                        {{ data.disabled ? 'Inactiva' : 'Activa' }}
+                        {{ data.deletedAt ? 'Inactiva' : 'Activa' }}
                       </div>
                     </div>
                   </div>
@@ -136,12 +136,32 @@
                     Editar
                   </button>
                   <button
+                    v-if="data.deletedAt"
                     type="button"
-                    class="btn btn-outline btn-error btn-md btn-wide lg:btn-md"
-                    disabled
+                    class="btn btn-success btn-md btn-wide lg:btn-md"
+                    :disabled="activatePending"
+                    @click="handleActivateVacancy"
                   >
-                    <AtomsIconOutlinedError />
-                    Eliminar
+                    <span
+                      v-if="activatePending"
+                      class="loading loading-spinner loading-sm"
+                    />
+                    <AtomsIconMicroCheck v-else />
+                    {{ activatePending ? 'Activando...' : 'Activar Plaza' }}
+                  </button>
+                  <button
+                    v-else
+                    type="button"
+                    class="btn btn-warning btn-md btn-wide lg:btn-md"
+                    :disabled="deactivatePending"
+                    @click="handleDeactivateVacancy"
+                  >
+                    <span
+                      v-if="deactivatePending"
+                      class="loading loading-spinner loading-sm"
+                    />
+                    <AtomsIconMicroXMark v-else />
+                    {{ deactivatePending ? 'Desactivando...' : 'Desactivar Plaza' }}
                   </button>
                 </div>
               </div>
@@ -204,7 +224,7 @@
               Error al cargar la información
             </h3>
             <div class="text-xs">
-              {{ error?.data?.message || 'No se pudo obtener la información de la plaza' }}
+              {{ 'No se pudo obtener la información de la plaza' }}
             </div>
           </div>
         </div>
@@ -225,7 +245,7 @@
               :class="{ 'tab-active': currentTab === 'students' }"
               :to="`/administrativo/plazas/${id}`"
             >
-              Estudiantes
+              Alumnos
             </NuxtLink>
             <NuxtLink
               role="tab"
@@ -276,9 +296,196 @@
                 v-else
                 :students="students"
                 order=""
-                :empty-message="'No hay estudiantes asignados a esta plaza.'"
+                :empty-message="'No hay alumnos asignados a esta plaza.'"
                 @update:order="() => {}"
                 @row-click="handleStudentRowClick"
+              />
+            </template>
+          </TemplatesListLayout>
+
+          <!-- Quarter Reports Tab Content -->
+          <TemplatesListLayout
+            v-else-if="currentTab === 'quarter-reports'"
+            class="mt-2"
+            :current-page="reportPage"
+            :total-pages="reportPages"
+            :show-pagination="!reportPending && reports.length > 0"
+            @previous-page="handleReportPageUpdate(reportPage - 1)"
+            @next-page="handleReportPageUpdate(reportPage + 1)"
+          >
+            <template #actions>
+              <select
+                id="report-status-filter"
+                :value="reportStatus"
+                class="select select-bordered w-full max-w-xs"
+                @change="handleReportStatusChange"
+              >
+                <option value="">
+                  Todos los estados
+                </option>
+                <option value="PENDING">
+                  Pendiente
+                </option>
+                <option value="APPROVED">
+                  Aprobado
+                </option>
+                <option value="REJECTED">
+                  Rechazado
+                </option>
+              </select>
+              <select
+                id="report-number-filter"
+                :value="reportNumber"
+                class="select select-bordered w-full max-w-xs"
+                @change="handleReportNumberChange"
+              >
+                <option value="">
+                  Todos los reportes
+                </option>
+                <option value="1">
+                  Reporte 1
+                </option>
+                <option value="2">
+                  Reporte 2
+                </option>
+              </select>
+            </template>
+
+            <template #content>
+              <!-- Loading State -->
+              <div
+                v-if="reportPending"
+                class="flex justify-center py-12"
+              >
+                <span class="loading loading-spinner loading-lg text-primary" />
+              </div>
+
+              <!-- Reports Table -->
+              <OrganismsReportsTable
+                v-else
+                :reports="reports"
+                :order="reportOrder"
+                :show-student="true"
+                :show-vacancy="false"
+                :empty-message="'No se encontraron reportes trimestrales para esta plaza.'"
+                @update:order="handleReportOrderUpdate"
+                @row-click="handleReportRowClick"
+                @row-approve="handleReportApprove"
+                @row-reject="handleReportReject"
+              />
+            </template>
+          </TemplatesListLayout>
+
+          <!-- Final Reports Tab Content -->
+          <TemplatesListLayout
+            v-else-if="currentTab === 'final-reports'"
+            class="mt-2"
+            :current-page="finalReportPage"
+            :total-pages="finalReportPages"
+            :show-pagination="!finalReportPending && finalReports.length > 0"
+            @previous-page="handleFinalReportPageUpdate(finalReportPage - 1)"
+            @next-page="handleFinalReportPageUpdate(finalReportPage + 1)"
+          >
+            <template #actions>
+              <select
+                id="final-report-status-filter"
+                :value="finalReportStatus"
+                class="select select-bordered w-full max-w-xs"
+                @change="handleFinalReportStatusChange"
+              >
+                <option value="">
+                  Todos los estados
+                </option>
+                <option value="PENDING">
+                  Pendiente
+                </option>
+                <option value="APPROVED">
+                  Aprobado
+                </option>
+                <option value="REJECTED">
+                  Rechazado
+                </option>
+              </select>
+            </template>
+
+            <template #content>
+              <!-- Loading State -->
+              <div
+                v-if="finalReportPending"
+                class="flex justify-center py-12"
+              >
+                <span class="loading loading-spinner loading-lg text-primary" />
+              </div>
+
+              <!-- Final Reports Table -->
+              <OrganismsFinalReportsTable
+                v-else
+                :final-reports="finalReports"
+                :order="finalReportOrder"
+                :show-student="true"
+                :show-vacancy="false"
+                :empty-message="'No se encontraron reportes finales para esta plaza.'"
+                @update:order="handleFinalReportOrderUpdate"
+                @row-click="handleFinalReportRowClick"
+                @row-approve="handleFinalReportApprove"
+                @row-reject="handleFinalReportReject"
+              />
+            </template>
+          </TemplatesListLayout>
+
+          <!-- Commission Offices Tab Content -->
+          <TemplatesListLayout
+            v-else-if="currentTab === 'commission-offices'"
+            class="mt-2"
+            :current-page="comissionPage"
+            :total-pages="comissionPages"
+            :show-pagination="!comissionPending && comissionOffices.length > 0"
+            @previous-page="handleComissionPageUpdate(comissionPage - 1)"
+            @next-page="handleComissionPageUpdate(comissionPage + 1)"
+          >
+            <template #actions>
+              <select
+                id="comission-status-filter"
+                :value="comissionStatus"
+                class="select select-bordered w-full max-w-xs"
+                @change="handleComissionStatusChange"
+              >
+                <option value="">
+                  Todos los estados
+                </option>
+                <option value="PENDING">
+                  Pendiente
+                </option>
+                <option value="APPROVED">
+                  Aprobado
+                </option>
+                <option value="REJECTED">
+                  Rechazado
+                </option>
+              </select>
+            </template>
+
+            <template #content>
+              <!-- Loading State -->
+              <div
+                v-if="comissionPending"
+                class="flex justify-center py-12"
+              >
+                <span class="loading loading-spinner loading-lg text-primary" />
+              </div>
+
+              <!-- Commission Offices Table -->
+              <OrganismsComissionOfficesTable
+                v-else
+                :comission-offices="comissionOffices"
+                :order="comissionOrder"
+                :show-student="true"
+                :show-vacancy="false"
+                :empty-message="'No se encontraron oficios de comisión para esta plaza.'"
+                @update:order="handleComissionOrderUpdate"
+                @row-click="handleComissionRowClick"
+                @row-approve="handleComissionApprove"
+                @row-reject="handleComissionReject"
               />
             </template>
           </TemplatesListLayout>
@@ -332,7 +539,15 @@
 <script setup lang="ts">
 import { useFetchVacancy } from '~/composables/useFetchVacancy'
 import { useFetchStudentsByVacancyId } from '~/composables/useFetchStudentsByVacancyId'
+import { useFetchComissionOffices } from '~/composables/useFetchComissionOffices'
+import { useFetchFinalReports } from '~/composables/useFetchFinalReports'
+import { useFetchReports } from '~/composables/useFetchReports'
 import { useEditVacancy } from '~/composables/useEditVacancy'
+import { usePatchComissionOffice } from '~/composables/usePatchComissionOffice'
+import { usePatchFinalReport } from '~/composables/usePatchFinalReport'
+import { usePatchReport } from '~/composables/usePatchReport'
+import { useActivateVacancy } from '~/composables/useActivateVacancy'
+import { useDeactivateVacancy } from '~/composables/useDeactivateVacancy'
 import { formatDateTime } from '~/common/dates'
 import { useNotificationStore } from '~/stores/notification'
 import { useLoginStore } from '~/stores/login'
@@ -341,7 +556,8 @@ import type { UpdateVacancy } from '~/types/api/vacancy.d'
 function pathToPage(page: string) {
   switch (page) {
     case '':
-    case '/':case 'alumnos':
+    case '/':
+    case 'alumnos':
       return 'students'
     case 'reportes-trimestrales':
       return 'quarter-reports'
@@ -391,6 +607,80 @@ const {
   error: studentsError
 } = useFetchStudentsByVacancyId({
   vacancyId: computed(() => parseInt(id.value, 10))
+})
+
+// Commission Office-related computed properties
+const comissionPage = computed(() => parseInt(route.query.comissionPage as string ?? '1', 10))
+const comissionStatus = computed(() => route.query.comissionStatus as string || undefined)
+const comissionLimit = computed(() => parseInt(route.query.comissionLimit as string ?? '10', 10))
+const comissionOffset = computed(() => (comissionPage.value - 1) * comissionLimit.value)
+const comissionOrder = computed(() => route.query.comissionOrder as string ?? '-ComissionOffices.createdAt')
+
+// Report-related computed properties
+const reportPage = computed(() => parseInt(route.query.reportPage as string ?? '1', 10))
+const reportStatus = computed(() => route.query.reportStatus as string || undefined)
+const reportNumber = computed(() => route.query.reportNumber as string || undefined)
+const reportLimit = computed(() => parseInt(route.query.reportLimit as string ?? '10', 10))
+const reportOffset = computed(() => (reportPage.value - 1) * reportLimit.value)
+const reportOrder = computed(() => route.query.reportOrder as string ?? '-Reports.createdAt')
+
+// Final Report-related computed properties
+const finalReportPage = computed(() => parseInt(route.query.finalReportPage as string ?? '1', 10))
+const finalReportStatus = computed(() => route.query.finalReportStatus as string || undefined)
+const finalReportLimit = computed(() => parseInt(route.query.finalReportLimit as string ?? '10', 10))
+const finalReportOffset = computed(() => (finalReportPage.value - 1) * finalReportLimit.value)
+const finalReportOrder = computed(() => route.query.finalReportOrder as string ?? '-FinalReports.createdAt')
+
+// Fetch commission offices for this vacancy
+const {
+  comissionOffices,
+  pages: comissionPages,
+  pending: comissionPending,
+  error: comissionError
+} = useFetchComissionOffices({
+  limit: comissionLimit,
+  offset: comissionOffset,
+  order: comissionOrder,
+  includeCycle: true,
+  includeVacancy: false,
+  includeStudent: true,
+  vacancyId: computed(() => parseInt(id.value, 10)),
+  status: computed(() => comissionStatus.value as 'APPROVED' | 'REJECTED' | 'PENDING' | undefined)
+})
+
+// Fetch reports for this vacancy
+const {
+  reports,
+  pages: reportPages,
+  pending: reportPending,
+  error: reportError
+} = useFetchReports({
+  limit: reportLimit,
+  offset: reportOffset,
+  order: reportOrder,
+  includeCycle: true,
+  includeVacancy: false,
+  includeStudent: true,
+  vacancyId: computed(() => parseInt(id.value, 10)),
+  status: computed(() => reportStatus.value as 'APPROVED' | 'REJECTED' | 'PENDING' | undefined),
+  reportNumber: computed(() => reportNumber.value as '1' | '2' | undefined)
+})
+
+// Fetch final reports for this vacancy
+const {
+  finalReports,
+  pages: finalReportPages,
+  pending: finalReportPending,
+  error: finalReportError
+} = useFetchFinalReports({
+  limit: finalReportLimit,
+  offset: finalReportOffset,
+  order: finalReportOrder,
+  includeCycle: true,
+  includeVacancy: false,
+  includeStudent: true,
+  vacancyId: computed(() => parseInt(id.value, 10)),
+  status: computed(() => finalReportStatus.value as 'APPROVED' | 'REJECTED' | 'PENDING' | undefined)
 })
 
 const editModal = ref(false)
@@ -461,20 +751,209 @@ const handleStudentRowClick = (studentId: number) => {
   router.push(`/administrativo/alumnos/${studentId}`)
 }
 
+// Commission Office handlers for component events
+const handleComissionPageUpdate = (newPage: number) => {
+  router.push({ query: { ...route.query, comissionPage: newPage } })
+}
+
+const handleComissionOrderUpdate = (newOrder: string) => {
+  router.push({ query: { ...route.query, comissionOrder: newOrder } })
+}
+
+const handleComissionStatusChange = (event: Event) => {
+  if (event.target instanceof HTMLSelectElement) {
+    const value = event.target.value
+    router.push({
+      query: {
+        ...route.query,
+        comissionStatus: value || undefined,
+        comissionPage: 1 // Reset to first page when filtering
+      }
+    })
+  }
+}
+
+const handleComissionRowClick = (comissionOfficeId: number, ctrlPressed: boolean) => {
+  console.log('Open comission office file:', comissionOfficeId, 'Ctrl pressed:', ctrlPressed)
+}
+
+const handleComissionApprove = async (comissionOfficeId: number) => {
+  await patchComissionOffice(comissionOfficeId, { status: 'APPROVED' })
+}
+
+const handleComissionReject = async (comissionOfficeId: number) => {
+  await patchComissionOffice(comissionOfficeId, { status: 'REJECTED' })
+}
+
+// Final Report handlers for component events
+const handleFinalReportPageUpdate = (newPage: number) => {
+  router.push({ query: { ...route.query, finalReportPage: newPage } })
+}
+
+const handleFinalReportOrderUpdate = (newOrder: string) => {
+  router.push({ query: { ...route.query, finalReportOrder: newOrder } })
+}
+
+const handleFinalReportStatusChange = (event: Event) => {
+  if (event.target instanceof HTMLSelectElement) {
+    const value = event.target.value
+    router.push({
+      query: {
+        ...route.query,
+        finalReportStatus: value || undefined,
+        finalReportPage: 1 // Reset to first page when filtering
+      }
+    })
+  }
+}
+
+const handleFinalReportRowClick = (finalReportId: number, ctrlPressed: boolean) => {
+  console.log('Open final report file:', finalReportId, 'Ctrl pressed:', ctrlPressed)
+}
+
+const handleFinalReportApprove = async (finalReportId: number) => {
+  await patchFinalReport(finalReportId, { status: 'APPROVED' })
+}
+
+const handleFinalReportReject = async (finalReportId: number) => {
+  await patchFinalReport(finalReportId, { status: 'REJECTED' })
+}
+
+// Report handlers for component events
+const handleReportPageUpdate = (newPage: number) => {
+  router.push({ query: { ...route.query, reportPage: newPage } })
+}
+
+const handleReportOrderUpdate = (newOrder: string) => {
+  router.push({ query: { ...route.query, reportOrder: newOrder } })
+}
+
+const handleReportStatusChange = (event: Event) => {
+  if (event.target instanceof HTMLSelectElement) {
+    const value = event.target.value
+    router.push({
+      query: {
+        ...route.query,
+        reportStatus: value || undefined,
+        reportPage: 1 // Reset to first page when filtering
+      }
+    })
+  }
+}
+
+const handleReportNumberChange = (event: Event) => {
+  if (event.target instanceof HTMLSelectElement) {
+    const value = event.target.value
+    router.push({
+      query: {
+        ...route.query,
+        reportNumber: value || undefined,
+        reportPage: 1 // Reset to first page when filtering
+      }
+    })
+  }
+}
+
+const handleReportRowClick = (reportId: number, ctrlPressed: boolean) => {
+  console.log('Open report file:', reportId, 'Ctrl pressed:', ctrlPressed)
+}
+
+const handleReportApprove = async (reportId: number) => {
+  await patchReport(reportId, { status: 'APPROVED' })
+}
+
+const handleReportReject = async (reportId: number) => {
+  await patchReport(reportId, { status: 'REJECTED' })
+}
+
+// Activate/Deactivate vacancy handlers
+const handleActivateVacancy = async () => {
+  if (!data.value) return
+
+  try {
+    await activateVacancy(data.value.id)
+    // Refresh vacancy data after successful activation
+    await refresh()
+  } catch (error) {
+    console.error('Error activating vacancy:', error)
+  }
+}
+
+const handleDeactivateVacancy = async () => {
+  if (!data.value) return
+
+  try {
+    await deactivateVacancy(data.value.id)
+    // Refresh vacancy data after successful deactivation
+    await refresh()
+  } catch (error) {
+    console.error('Error deactivating vacancy:', error)
+  }
+}
+
+// Patch commission office functionality
+const { mutate: patchComissionOffice } = usePatchComissionOffice()
+
+// Patch final report functionality
+const { mutate: patchFinalReport } = usePatchFinalReport()
+
+// Patch report functionality
+const { mutate: patchReport } = usePatchReport()
+
+// Activate/Deactivate vacancy functionality
+const { mutate: activateVacancy, pending: activatePending, error: _activateError } = useActivateVacancy()
+const { mutate: deactivateVacancy, pending: deactivatePending, error: _deactivateError } = useDeactivateVacancy()
+
 // Watch for students errors
 watch(studentsError, (newError) => {
   if (newError) {
     console.error('Error fetching students:', newError)
     notificationStore.add({
       type: 'error',
-      title: 'Error al cargar estudiantes',
-      description: 'Ocurrió un error al cargar los estudiantes de la plaza'
+      title: 'Error al cargar alumnos',
+      description: 'Ocurrió un error al cargar los alumnos de la plaza'
+    })
+  }
+})
+
+// Watch for commission office errors
+watch(comissionError, (newError) => {
+  if (newError) {
+    console.error('Error fetching commission offices:', newError)
+    notificationStore.add({
+      type: 'error',
+      title: 'Error al cargar oficios de comisión',
+      description: 'Ocurrió un error al cargar los oficios de comisión de la plaza'
+    })
+  }
+})
+
+// Watch for report errors
+watch(reportError, (newError) => {
+  if (newError) {
+    console.error('Error fetching reports:', newError)
+    notificationStore.add({
+      type: 'error',
+      title: 'Error al cargar reportes',
+      description: 'Ocurrió un error al cargar los reportes trimestrales de la plaza'
+    })
+  }
+})
+
+// Watch for final report errors
+watch(finalReportError, (newError) => {
+  if (newError) {
+    console.error('Error fetching final reports:', newError)
+    notificationStore.add({
+      type: 'error',
+      title: 'Error al cargar reportes finales',
+      description: 'Ocurrió un error al cargar los reportes finales de la plaza'
     })
   }
 })
 
 useHead({
-  title: computed(() => data.value ? `${data.value.name} - Información de la plazq` : 'Cargando...'),
+  title: computed(() => data.value ? `${data.value.name} - Información de la plaza` : 'Cargando...'),
   meta: [
     {
       name: 'description',

--- a/pages/registro-alumno.vue
+++ b/pages/registro-alumno.vue
@@ -83,7 +83,7 @@
               class="alert alert-error mt-4"
             >
               <span v-if="'statusCode' in addStudentError && addStudentError.statusCode === 409">Estos datos ya están registrados</span>
-              <span v-else>{{ 'Error al registrar estudiante' }}</span>
+              <span v-else>{{ 'Error al registrar alumno' }}</span>
             </div>
             <div class="mt-6">
               <button

--- a/pages/sign-in.vue
+++ b/pages/sign-in.vue
@@ -16,7 +16,7 @@
               label="Tipo de usuario"
               :options="[
                 { value: 'user', label: 'Administrativo' },
-                { value: 'student', label: 'Estudiante' }
+                { value: 'student', label: 'Alumno' }
               ]"
               placeholder="Escoge un tipo"
               required

--- a/stores/login.ts
+++ b/stores/login.ts
@@ -70,7 +70,7 @@ export const useLoginStore = defineStore('login', () => {
     const response = await Axios<{ token: string }>({
       method: 'POST',
       baseURL: config.public.serverHost,
-      url: '/students/auth',
+      url: '/api/student/auth',
       data: {
         email,
         password

--- a/types/api/comission-office.d.ts
+++ b/types/api/comission-office.d.ts
@@ -21,4 +21,4 @@ export interface ComissionOfficeWithRelations extends ComissionOffice {
 }
 
 export type CreateComissionOffice = Omit<ComissionOffice, 'id' | 'createdAt' | 'updatedAt'>
-export type UpdateComissionOffice = Partial<Omit<ComissionOffice, 'id' | 'createdAt' | 'updatedAt'>>
+export type UpdateComissionOffice = Partial<Omit<ComissionOffice, 'id' | 'createdAt' | 'updatedAt' | 'cycleId' | 'vacancyId' | 'studentId'>>

--- a/types/api/final-reports.d.ts
+++ b/types/api/final-reports.d.ts
@@ -1,0 +1,24 @@
+import type { Student } from './student.d'
+import type { Vacancy } from './vacancy.d'
+import type { Cycle } from './cycle.d'
+
+export interface FinalReport {
+  id: number
+  studentId: number
+  vacancyId: number
+  cycleId: number
+  status: 'APPROVED' | 'REJECTED' | 'PENDING'
+  hours: number // Integer
+  fileId: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface FinalReportWithRelations extends FinalReport {
+  student?: Student
+  vacancy?: Vacancy
+  cycle?: Cycle
+}
+
+export type CreateFinalReport = Omit<FinalReport, 'id' | 'createdAt' | 'updatedAt'>
+export type UpdateFinalReport = Partial<Omit<FinalReport, 'id' | 'createdAt' | 'updatedAt' | 'cycleId' | 'vacancyId' | 'studentId'>>

--- a/types/api/report.d.ts
+++ b/types/api/report.d.ts
@@ -1,0 +1,25 @@
+import type { Student } from './student.d'
+import type { Vacancy } from './vacancy.d'
+import type { Cycle } from './cycle.d'
+
+interface Report {
+  id: number
+  studentId: number
+  vacancyId: number
+  cycleId: number
+  reportNumber: '1' | '2'
+  status: 'APPROVED' | 'REJECTED' | 'PENDING'
+  hours: number // integer
+  fileId: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface ReportWithRelations extends Report {
+  student?: Student
+  vacancy?: Vacancy
+  cycle?: Cycle
+}
+
+export type CreateReport = Omit<Report, 'id' | 'createdAt' | 'updatedAt'>
+export type UpdateReport = Partial<Omit<Report, 'id' | 'createdAt' | 'cycleId' | 'vacancyId' | 'studentId' | 'reportNumber'>>

--- a/types/api/student.d.ts
+++ b/types/api/student.d.ts
@@ -7,6 +7,7 @@ export interface Student {
   careerId: number
   email: string
   telephone: string
+  deletedAt: string | null
   createdAt: string // ISO string
   updatedAt: string // ISO string
 }

--- a/types/api/vacancy.d.ts
+++ b/types/api/vacancy.d.ts
@@ -11,6 +11,7 @@ interface Vacancy {
   disabled: boolean
   createdAt: string // ISO string
   updatedAt: string // ISO string
+  deletedAt: string | null // ISO string or null when active
 }
 
 interface VacancyWithRelations extends Vacancy {
@@ -19,6 +20,6 @@ interface VacancyWithRelations extends Vacancy {
 }
 
 export type CreateVacancy = Omit<Vacancy, 'id' | 'createdAt' | 'updatedAt'>
-export type UpdateVacancy = Omit<Vacancy, 'id' | 'createdAt' | 'updatedAt' | 'departmentId' | 'cycleId'>
+export type UpdateVacancy = Omit<Vacancy, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt' | 'departmentId' | 'cycleId'>
 
 export type { Vacancy, VacancyWithRelations }

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,40 @@
   dependencies:
     mime "^3.0.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
+"@edge-runtime/format@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/format/-/format-2.2.1.tgz#10dcedb0d7c2063c9ee360fbab23846c8720f986"
+  integrity sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==
+
+"@edge-runtime/node-utils@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz#17ac98dd8a39e194c4fd49d66f3579ec5b125a78"
+  integrity sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==
+
+"@edge-runtime/ponyfill@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz#9bec9feff18623f9f3ebe2f4ad8f0475c644ed07"
+  integrity sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==
+
+"@edge-runtime/primitives@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/primitives/-/primitives-4.1.0.tgz#43c6e793362f3333acf0955a75b5735b34035494"
+  integrity sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==
+
+"@edge-runtime/vm@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@edge-runtime/vm/-/vm-3.2.0.tgz#8a735241d14e9fdad85497b8b17d0ea157df4710"
+  integrity sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==
+  dependencies:
+    "@edge-runtime/primitives" "4.1.0"
+
 "@emnapi/core@^1.4.5":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.5.0.tgz#85cd84537ec989cebb2343606a1ee663ce4edaf0"
@@ -784,6 +818,11 @@
   dependencies:
     levn "^0.4.1"
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
+
 "@google-cloud/dialogflow@^7.0.1":
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/dialogflow/-/dialogflow-7.0.1.tgz#ae363675eae40078808411808bf2bf1392b74365"
@@ -920,7 +959,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
@@ -947,6 +986,14 @@
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
@@ -1505,6 +1552,16 @@
   resolved "https://registry.yarnpkg.com/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.86.0.tgz#15435851235b455afdd27bccd0bff3933fe3f543"
   integrity sha512-FTso24eQh3vPTe/SOTf0/RXfjJ13tsk5fw728fm+z5y6Rb+mmEBfyVT6XxyGhEwtdfnRSZawheX74/9caI1etw==
 
+"@oxc-project/runtime@=0.82.3":
+  version "0.82.3"
+  resolved "https://registry.yarnpkg.com/@oxc-project/runtime/-/runtime-0.82.3.tgz#e12eedb0f5ee6b9af6b3042ee1e3c9bb5397d016"
+  integrity sha512-LNh5GlJvYHAnMurO+EyA8jJwN1rki7l3PSHuosDh2I7h00T6/u9rCkUjg/SvPmT1CZzvhuW0y+gf7jcqUy/Usg==
+
+"@oxc-project/types@=0.82.3":
+  version "0.82.3"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.82.3.tgz#347ade99a5fd7bb43ff9c3f37ae06ebcf0e62129"
+  integrity sha512-6nCUxBnGX0c6qfZW5MaF6/fmu5dHJDMiMPaioKHKs5mi5+8/FHQ7WGjgQIz1zxpmceMYfdIXkOaLYE+ejbuOtA==
+
 "@oxc-project/types@^0.86.0":
   version "0.86.0"
   resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.86.0.tgz#8de353dda445ded4fd60f3f7355353e2e0db59d0"
@@ -1781,12 +1838,84 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@rolldown/binding-android-arm64@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.35.tgz#661549fc72757e5750280607190265d9e77fc5e4"
+  integrity sha512-zVTg0544Ib1ldJSWwjy8URWYHlLFJ98rLnj+2FIj5fRs4KqGKP4VgH/pVUbXNGxeLFjItie6NSK1Un7nJixneQ==
+
+"@rolldown/binding-darwin-arm64@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.35.tgz#4b6de3cd4ad988cca2f0dba78afd8162a0cec0ff"
+  integrity sha512-WPy0qx22CABTKDldEExfpYHWHulRoPo+m/YpyxP+6ODUPTQexWl8Wp12fn1CVP0xi0rOBj7ugs6+kKMAJW56wQ==
+
+"@rolldown/binding-darwin-x64@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.35.tgz#9c20db7c0261caf0659324ce5d9d5a0f0a31da15"
+  integrity sha512-3k1TabJafF/GgNubXMkfp93d5p30SfIMOmQ5gm1tFwO+baMxxVPwDs3FDvSl+feCWwXxBA+bzemgkaDlInmp1Q==
+
+"@rolldown/binding-freebsd-x64@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.35.tgz#fc5084ae50bc89776ebe212f0d7f74e890fc6eec"
+  integrity sha512-GAiapN5YyIocnBVNEiOxMfWO9NqIeEKKWohj1sPLGc61P+9N1meXOOCiAPbLU+adXq0grtbYySid+Or7f2q+Mg==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.35.tgz#bce5b7227ee825e5606bfa79cdc52726ce2049bb"
+  integrity sha512-okPKKIE73qkUMvq7dxDyzD0VIysdV4AirHqjf8tGTjuNoddUAl3WAtMYbuZCEKJwUyI67UINKO1peFVlYEb+8w==
+
+"@rolldown/binding-linux-arm64-gnu@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.35.tgz#c9817cf0c85467e94c71fe01a5d7120f028c91ca"
+  integrity sha512-Nky8Q2cxyKVkEETntrvcmlzNir5khQbDfX3PflHPbZY7XVZalllRqw7+MW5vn+jTsk5BfKVeLsvrF4344IU55g==
+
+"@rolldown/binding-linux-arm64-musl@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.35.tgz#a16ee257feaf6401cd48dbb40463388df83a5688"
+  integrity sha512-8aHpWVSfZl3Dy2VNFG9ywmlCPAJx45g0z+qdOeqmYceY7PBAT4QGzii9ig1hPb1pY8K45TXH44UzQwr2fx352Q==
+
+"@rolldown/binding-linux-x64-gnu@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.35.tgz#b0f5697ace246f5d7f8bd7f98a20c4bb5bc2c1d8"
+  integrity sha512-1r1Ac/vTcm1q4kRiX/NB6qtorF95PhjdCxKH3Z5pb+bWMDZnmcz18fzFlT/3C6Qpj/ZqUF+EUrG4QEDXtVXGgg==
+
+"@rolldown/binding-linux-x64-musl@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.35.tgz#31505abe4aa675cebfda763881c3abe37f957081"
+  integrity sha512-AFl1LnuhUBDfX2j+cE6DlVGROv4qG7GCPDhR1kJqi2+OuXGDkeEjqRvRQOFErhKz1ckkP/YakvN7JheLJ2PKHQ==
+
+"@rolldown/binding-openharmony-arm64@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.35.tgz#e9777f2f0ecd131b9390d3048024628d450b5cf9"
+  integrity sha512-Tuwb8vPs+TVJlHhyLik+nwln/burvIgaPDgg6wjNZ23F1ttjZi0w0rQSZfAgsX4jaUbylwCETXQmTp3w6vcJMw==
+
+"@rolldown/binding-wasm32-wasi@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.35.tgz#cde1aef57b49ed3da48dbb37aee8a8941f3f7fa5"
+  integrity sha512-rG0OozgqNUYcpu50MpICMlJflexRVtQfjlN9QYf6hoel46VvY0FbKGwBKoeUp2K5D4i8lV04DpEMfTZlzRjeiA==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^1.0.3"
+
+"@rolldown/binding-win32-arm64-msvc@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.35.tgz#db57d76c8319939b114a4cfa9b3e09fa838dc1c2"
+  integrity sha512-WeOfAZrycFo9+ZqTDp3YDCAOLolymtKGwImrr9n+OW0lpwI2UKyKXbAwGXRhydAYbfrNmuqWyfyoAnLh3X9Hjg==
+
+"@rolldown/binding-win32-ia32-msvc@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.35.tgz#ec6427a5393e082112bc8bb1aac7ac5a069d0036"
+  integrity sha512-XkLT7ikKGiUDvLh7qtJHRukbyyP1BIrD1xb7A+w4PjIiOKeOH8NqZ+PBaO4plT7JJnLxx+j9g/3B7iylR1nTFQ==
+
+"@rolldown/binding-win32-x64-msvc@1.0.0-beta.35":
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.35.tgz#19788b2ec97679b1ebec305e4fec39bfa6db352d"
+  integrity sha512-rftASFKVzjbcQHTCYHaBIDrnQFzbeV50tm4hVugG3tPjd435RHZC2pbeGV5IPdKEqyJSuurM/GfbV3kLQ3LY/A==
+
 "@rolldown/pluginutils@1.0.0-beta.29":
   version "1.0.0-beta.29"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz#f8fc9a8788757dccba0d3b7fee93183621773d4c"
   integrity sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==
 
-"@rolldown/pluginutils@^1.0.0-beta.34":
+"@rolldown/pluginutils@1.0.0-beta.35", "@rolldown/pluginutils@^1.0.0-beta.34":
   version "1.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz#1a477e7742b154b67519d40e4fc17485de338e7a"
   integrity sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==
@@ -1967,6 +2096,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.1.tgz#13f758c97b9fbbac56b6928547a3ff384e7cfb3e"
   integrity sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==
 
+"@sinclair/typebox@0.25.24":
+  version "0.25.24"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
+  integrity sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==
+
 "@sindresorhus/is@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-7.0.2.tgz#a0df078a8d29f9741503c5a9c302de474ec8564a"
@@ -1998,10 +2132,40 @@
     estraverse "^5.3.0"
     picomatch "^4.0.2"
 
-"@tootallnate/once@2":
+"@tootallnate/once@2", "@tootallnate/once@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@ts-morph/common@~0.11.0":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.11.1.tgz#281af2a0642b19354d8aa07a0d50dfdb4aa8164e"
+  integrity sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==
+  dependencies:
+    fast-glob "^3.2.7"
+    minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@tybys/wasm-util@^0.10.0":
   version "0.10.0"
@@ -2037,7 +2201,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/json-schema@^7.0.15":
+"@types/json-schema@^7.0.15", "@types/json-schema@^7.0.6":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -2062,6 +2226,11 @@
   integrity sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==
   dependencies:
     undici-types "~6.20.0"
+
+"@types/node@16.18.11":
+  version "16.18.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.11.tgz#cbb15c12ca7c16c85a72b6bdc4d4b01151bb3cae"
+  integrity sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==
 
 "@types/node@>=13.7.0":
   version "22.15.17"
@@ -2196,7 +2365,126 @@
     hookable "^5.5.3"
     unhead "2.0.14"
 
-"@vercel/nft@^0.30.1":
+"@vercel/blob@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@vercel/blob/-/blob-1.0.2.tgz#044cdcb6c223f23b68f9e5ac626843fd20e415a3"
+  integrity sha512-Im/KeFH4oPx7UsM+QiteimnE07bIUD7JK6CBafI9Z0jRFogaialTBMiZj8EKk/30ctUYsrpIIyP9iIY1YxWnUQ==
+  dependencies:
+    async-retry "^1.3.3"
+    is-buffer "^2.0.5"
+    is-node-process "^1.2.0"
+    throttleit "^2.1.0"
+    undici "^5.28.4"
+
+"@vercel/build-utils@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-12.1.0.tgz#9962f2b28a59fa949c27dc355655b06efafa5d54"
+  integrity sha512-yqpAh2KHm9iWUXo/aRWiLIxi8dMAwFtse2iZsg2QNEMs9W20va6L8PMFvdAa5MX9pgRwc38gbjD3V7drxSwq4g==
+
+"@vercel/detect-agent@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@vercel/detect-agent/-/detect-agent-1.0.0.tgz#acbfb2214fd8628dcc76c47ed62fdb10c893d25c"
+  integrity sha512-AIPgNkmtFcDgPCl+xvTT1ga90OL7OTX2RKM4zu0PMpwBthPfN2DpdHy10n3bh8K+CA22GDU0/ncjzprZsrk0sw==
+
+"@vercel/error-utils@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@vercel/error-utils/-/error-utils-2.0.3.tgz#72575bf3a3ff3e67f474364e24e753d113c5b79a"
+  integrity sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==
+
+"@vercel/express@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@vercel/express/-/express-0.0.22.tgz#69f3fcadf43f5f3d0c5fcd17cf26758ae10d2b9a"
+  integrity sha512-tbTy5tLA2ouIlLtiJvkb4VcCgzbgOonTupYYJzJrhFd4FDxcS0nSSmu7O/QDivpZz5c3Uk9xW5qLYnPn4rjrXQ==
+  dependencies:
+    "@vercel/nft" "0.30.1"
+    "@vercel/node" "5.3.24"
+    "@vercel/static-config" "3.1.2"
+    fs-extra "11.1.0"
+    path-to-regexp "8.3.0"
+    rolldown "1.0.0-beta.35"
+    ts-morph "12.0.0"
+    zod "3.22.4"
+
+"@vercel/fun@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@vercel/fun/-/fun-1.1.6.tgz#f34094d65d1ef1cd80be9771dcacf99d36b0e29a"
+  integrity sha512-xDiM+bD0fSZyzcjsAua3D+guXclvHOSTzr03UcZEQwYzIjwWjLduT7bl2gAaeNIe7fASAIZd0P00clcj0On4rQ==
+  dependencies:
+    "@tootallnate/once" "2.0.0"
+    async-listen "1.2.0"
+    debug "4.3.4"
+    generic-pool "3.4.2"
+    micro "9.3.5-canary.3"
+    ms "2.1.1"
+    node-fetch "2.6.7"
+    path-match "1.2.4"
+    promisepipe "3.0.0"
+    semver "7.5.4"
+    stat-mode "0.3.0"
+    stream-to-promise "2.2.0"
+    tar "6.2.1"
+    tinyexec "0.3.2"
+    tree-kill "1.2.2"
+    uid-promise "1.0.0"
+    xdg-app-paths "5.1.0"
+    yauzl-promise "2.1.3"
+
+"@vercel/gatsby-plugin-vercel-analytics@1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@vercel/gatsby-plugin-vercel-analytics/-/gatsby-plugin-vercel-analytics-1.0.11.tgz#07e6a02665c340ad31ad9d9d3b0df00a30a32aed"
+  integrity sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==
+  dependencies:
+    web-vitals "0.2.4"
+
+"@vercel/gatsby-plugin-vercel-builder@2.0.95":
+  version "2.0.95"
+  resolved "https://registry.yarnpkg.com/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.0.95.tgz#28d08512f86e3e4129f7819907d3057e869d5434"
+  integrity sha512-G0sHN+aNMhQud+J0qksXwsnlYLFSC6h253KlvnxAAqxDjmZVKE6SfVmXWHLklVAfbvg5un9fwYDCMY0H3wiiUQ==
+  dependencies:
+    "@sinclair/typebox" "0.25.24"
+    "@vercel/build-utils" "12.1.0"
+    esbuild "0.14.47"
+    etag "1.8.1"
+    fs-extra "11.1.0"
+
+"@vercel/go@3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@vercel/go/-/go-3.2.3.tgz#88ca10154757574fc6d37b2b889fb9ebc678459d"
+  integrity sha512-PErgHlV7cf8hyPq31aRsL4xm5t4rCSO6vN5AQLlAGSy3ctdgqG7sI6hq/CAKo3CfgIhVHUwNYapFJgGJB/s4OA==
+
+"@vercel/h3@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@vercel/h3/-/h3-0.1.2.tgz#3e94992bf0ab2aa2d241217b9640475837ab608c"
+  integrity sha512-6KkCdsqPBPR83b6R6jvC/2TgU1jWdZI8cTMq/OcgcNLmni5mHFxy+YMaXgxPXgevUxve5+ag7c1bv66wPPYZZw==
+  dependencies:
+    "@vercel/node" "5.3.24"
+    "@vercel/static-config" "3.1.2"
+
+"@vercel/hono@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@vercel/hono/-/hono-0.1.2.tgz#e4321109e964161ec453414fe7f68af5b2801984"
+  integrity sha512-sVjshneJZ6ww5PSU4DhUK9dPr5Q9/UREKMk/00oCUw/XZhosJ2OxXYvZzDlexB1YtgqtbAxZUkE0jWkTwPOSWQ==
+  dependencies:
+    "@vercel/node" "5.3.24"
+    "@vercel/static-config" "3.1.2"
+    ts-morph "12.0.0"
+
+"@vercel/hydrogen@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@vercel/hydrogen/-/hydrogen-1.2.4.tgz#6ee0e596c3fde804cc334c52f7080af94e4a8076"
+  integrity sha512-eb16oesfgHuBlXxe+WqI+rMdP4QpeHXLJh9ropFy+StkWC2F0ZFKegutEpvJCRg0FHttRnn9uMzMmzJ2F4xKkg==
+  dependencies:
+    "@vercel/static-config" "3.1.2"
+    ts-morph "12.0.0"
+
+"@vercel/next@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@vercel/next/-/next-4.13.0.tgz#1841af0f7ace530ba525b0de48d992f4cb4c3c6a"
+  integrity sha512-DIfZucRjTihIUolR2v9MpugpazPoo02NkwA+Pk+/NmmSunf7XLSC42QG1OkSyzeGsXQ0t4nPAY6NQKYp9+NZnQ==
+  dependencies:
+    "@vercel/nft" "0.30.1"
+
+"@vercel/nft@0.30.1", "@vercel/nft@^0.30.1":
   version "0.30.1"
   resolved "https://registry.yarnpkg.com/@vercel/nft/-/nft-0.30.1.tgz#75a60ecf3aee6113ec0d4082d66ad5dd39ab4eca"
   integrity sha512-2mgJZv4AYBFkD/nJ4QmiX5Ymxi+AisPLPcS/KPXVqniyQNqKXX+wjieAbDXQP3HcogfEbpHoRMs49Cd4pfkk8g==
@@ -2213,6 +2501,85 @@
     node-gyp-build "^4.2.2"
     picomatch "^4.0.2"
     resolve-from "^5.0.0"
+
+"@vercel/node@5.3.24":
+  version "5.3.24"
+  resolved "https://registry.yarnpkg.com/@vercel/node/-/node-5.3.24.tgz#2f56c0eb26560cceaa1888657e3f06b1e76ccdb3"
+  integrity sha512-yk8pdoNbAbUO5zcmqyMPQ6kNvN896c/gJbsiGS5RvO9Gyehib5IxUOap6SnLSExH4tWAl1XTbOptfuysqZpYog==
+  dependencies:
+    "@edge-runtime/node-utils" "2.3.0"
+    "@edge-runtime/primitives" "4.1.0"
+    "@edge-runtime/vm" "3.2.0"
+    "@types/node" "16.18.11"
+    "@vercel/build-utils" "12.1.0"
+    "@vercel/error-utils" "2.0.3"
+    "@vercel/nft" "0.30.1"
+    "@vercel/static-config" "3.1.2"
+    async-listen "3.0.0"
+    cjs-module-lexer "1.2.3"
+    edge-runtime "2.5.9"
+    es-module-lexer "1.4.1"
+    esbuild "0.14.47"
+    etag "1.8.1"
+    mime-types "2.1.35"
+    node-fetch "2.6.9"
+    path-to-regexp "6.1.0"
+    path-to-regexp-updated "npm:path-to-regexp@6.3.0"
+    ts-morph "12.0.0"
+    ts-node "10.9.1"
+    typescript "4.9.5"
+    undici "5.28.4"
+
+"@vercel/python@5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@vercel/python/-/python-5.0.5.tgz#5f87a4cfed1e09744b2ab6d3cb83304ed2c5e91a"
+  integrity sha512-XLG/fDe2hflzNtSWuoASTo+N2c4hl6SbcufvBRYa7BnBQK9t4ZH1IEu+vJkq2AUoVczp5JEYLEXkIGm8KBtoeg==
+
+"@vercel/redwood@2.3.6":
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@vercel/redwood/-/redwood-2.3.6.tgz#3ec66d410564f08a2f6dd6bc34fd7d175a59d8b8"
+  integrity sha512-Rm9xECWNIJOwtPsZ1/XcgyJj95KM7cWwNHYPMw8dzFAnLQGyapGe/YHEjxV6POI2RF8R0nFmU1t+45XBweYJJA==
+  dependencies:
+    "@vercel/nft" "0.30.1"
+    "@vercel/static-config" "3.1.2"
+    semver "6.3.1"
+    ts-morph "12.0.0"
+
+"@vercel/remix-builder@5.4.12":
+  version "5.4.12"
+  resolved "https://registry.yarnpkg.com/@vercel/remix-builder/-/remix-builder-5.4.12.tgz#e338b3b8bb6bb2e63846a579659bde57bdfe91d5"
+  integrity sha512-25HHNUpIu3TfuZnphDDX7yG+4QugbxDq0bB8d1KCeOWsKH+z0Zscg7rchs3Pqy6kdhV/US6zH+YAogtwMvdDMg==
+  dependencies:
+    "@vercel/error-utils" "2.0.3"
+    "@vercel/nft" "0.30.1"
+    "@vercel/static-config" "3.1.2"
+    path-to-regexp "6.1.0"
+    path-to-regexp-updated "npm:path-to-regexp@6.3.0"
+    ts-morph "12.0.0"
+
+"@vercel/ruby@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ruby/-/ruby-2.2.1.tgz#c36ba0568531f30193479d2442177201142fbadb"
+  integrity sha512-DsmTCggOa/Uvt/9JkafXx9U+Bz5eNIb6Bs422EOQo2zKwcxW88ITSh8mM5m0dQ0+B4k02X/moVim6iFa4sjazg==
+
+"@vercel/static-build@2.7.23":
+  version "2.7.23"
+  resolved "https://registry.yarnpkg.com/@vercel/static-build/-/static-build-2.7.23.tgz#761896bde9ddbf2d38c0a7102502f9dd210eb8b2"
+  integrity sha512-F9u6FGWShfHbhldA9nRW6FdHfM7nVESYVGg+XOuWUlnyHnN6HiOFAze8wCb5yOuF5XXlp3bpn2IUByy4CPnjHQ==
+  dependencies:
+    "@vercel/gatsby-plugin-vercel-analytics" "1.0.11"
+    "@vercel/gatsby-plugin-vercel-builder" "2.0.95"
+    "@vercel/static-config" "3.1.2"
+    ts-morph "12.0.0"
+
+"@vercel/static-config@3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@vercel/static-config/-/static-config-3.1.2.tgz#813bd7584fe3ef003634c3a9fd5d72095d2003d6"
+  integrity sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==
+  dependencies:
+    ajv "8.6.3"
+    json-schema-to-ts "1.6.4"
+    ts-morph "12.0.0"
 
 "@vitejs/plugin-vue-jsx@^5.1.1":
   version "5.1.1"
@@ -2574,15 +2941,22 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
+  version "8.15.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
+  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+
 acorn@^8.14.0, acorn@^8.6.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
-
-acorn@^8.15.0:
-  version "8.15.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
-  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
 agent-base@6:
   version "6.0.2"
@@ -2595,6 +2969,16 @@ agent-base@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
   integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
+
+ajv@8.6.3:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -2633,12 +3017,12 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-ansis@^4.1.0:
+ansis@^4.0.0, ansis@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.1.0.tgz#cd43ecd3f814f37223e518291c0e0b04f2915a0d"
   integrity sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==
 
-any-promise@^1.0.0:
+any-promise@^1.0.0, any-promise@^1.1.0, any-promise@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
@@ -2682,6 +3066,16 @@ are-docs-informative@^0.0.2:
   resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
   integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
 
+arg@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
+  integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 arg@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
@@ -2707,6 +3101,28 @@ ast-walker-scope@^0.8.1:
   dependencies:
     "@babel/parser" "^7.28.3"
     ast-kit "^2.1.2"
+
+async-listen@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/async-listen/-/async-listen-1.2.0.tgz#861ab6f92e1703ba54498b10ddb9b5da7b69f363"
+  integrity sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==
+
+async-listen@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/async-listen/-/async-listen-3.0.0.tgz#2e5941390b7d8c753d4dbe94bc6aecbdde52ec5e"
+  integrity sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==
+
+async-listen@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/async-listen/-/async-listen-3.0.1.tgz#cbe4edeace2b93ebf5cf8092899ee139457978b7"
+  integrity sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==
+
+async-retry@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
 
 async-sema@^3.1.1:
   version "3.1.1"
@@ -2850,6 +3266,11 @@ buffer-crc32@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz#a10993b9055081d55304bd9feb4a072de179f405"
   integrity sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -2886,6 +3307,11 @@ bundle-require@^5.0.0:
   integrity sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==
   dependencies:
     load-tsconfig "^0.2.3"
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 c12@^2.0.1:
   version "2.0.1"
@@ -2974,6 +3400,13 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chokidar@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.0.tgz#4d603963e5dd762dc5c7bb1cb5664e53a3002225"
+  integrity sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==
+  dependencies:
+    readdirp "^4.0.1"
+
 chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -3025,6 +3458,11 @@ citty@^0.1.5, citty@^0.1.6:
   dependencies:
     consola "^3.2.3"
 
+cjs-module-lexer@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
+  integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
+
 clean-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
@@ -3054,6 +3492,11 @@ cluster-key-slot@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
   integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
+code-block-writer@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-10.1.1.tgz#ad5684ed4bfb2b0783c8b131281ae84ee640a42f"
+  integrity sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -3150,6 +3593,16 @@ consola@^3.4.0, consola@^3.4.2:
   resolved "https://registry.yarnpkg.com/consola/-/consola-3.4.2.tgz#5af110145397bb67afdab77013fdc34cae590ea7"
   integrity sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==
 
+content-type@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
+convert-hrtime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-3.0.0.tgz#62c7593f5809ca10be8da858a6d2f702bcda00aa"
+  integrity sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -3201,6 +3654,11 @@ crc32-stream@^6.0.0:
   dependencies:
     crc-32 "^1.2.0"
     readable-stream "^4.0.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 croner@^9.1.0:
   version "9.1.0"
@@ -3383,6 +3841,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, d
   dependencies:
     ms "^2.1.3"
 
+debug@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -3450,6 +3915,11 @@ depd@2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+
 destr@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.3.tgz#7f9e97cb3d16dbdca7be52aca1644ce402cfe449"
@@ -3479,6 +3949,11 @@ didyoumean@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^8.0.2:
   version "8.0.2"
@@ -3585,6 +4060,21 @@ ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
+edge-runtime@2.5.9:
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/edge-runtime/-/edge-runtime-2.5.9.tgz#9daeb329f0339b8377483f230789b3d68f45f1d9"
+  integrity sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==
+  dependencies:
+    "@edge-runtime/format" "2.2.1"
+    "@edge-runtime/ponyfill" "2.4.2"
+    "@edge-runtime/vm" "3.2.0"
+    async-listen "3.0.1"
+    mri "1.2.0"
+    picocolors "1.0.0"
+    pretty-ms "7.0.1"
+    signal-exit "4.0.2"
+    time-span "4.0.0"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -3621,6 +4111,13 @@ end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+end-of-stream@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.1.0.tgz#e9353258baa9108965efc41cb0ef8ade2f3cfb07"
+  integrity sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==
+  dependencies:
+    once "~1.3.0"
 
 enhanced-resolve@^5.14.1:
   version "5.17.1"
@@ -3662,6 +4159,11 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
+es-module-lexer@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
+  integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
+
 es-module-lexer@^1.5.3:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
@@ -3688,6 +4190,132 @@ es-set-tostringtag@^2.1.0:
     get-intrinsic "^1.2.6"
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
+
+esbuild-android-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz#ef95b42c67bcf4268c869153fa3ad1466c4cea6b"
+  integrity sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==
+
+esbuild-android-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz#4ebd7ce9fb250b4695faa3ee46fd3b0754ecd9e6"
+  integrity sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==
+
+esbuild-darwin-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz#e0da6c244f497192f951807f003f6a423ed23188"
+  integrity sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==
+
+esbuild-darwin-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz#cd40fd49a672fca581ed202834239dfe540a9028"
+  integrity sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==
+
+esbuild-freebsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz#8da6a14c095b29c01fc8087a16cb7906debc2d67"
+  integrity sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==
+
+esbuild-freebsd-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz#ad31f9c92817ff8f33fd253af7ab5122dc1b83f6"
+  integrity sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==
+
+esbuild-linux-32@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz#de085e4db2e692ea30c71208ccc23fdcf5196c58"
+  integrity sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==
+
+esbuild-linux-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz#2a9321bbccb01f01b04cebfcfccbabeba3658ba1"
+  integrity sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==
+
+esbuild-linux-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz#b9da7b6fc4b0ca7a13363a0c5b7bb927e4bc535a"
+  integrity sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==
+
+esbuild-linux-arm@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz#56fec2a09b9561c337059d4af53625142aded853"
+  integrity sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==
+
+esbuild-linux-mips64le@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz#9db21561f8f22ed79ef2aedb7bbef082b46cf823"
+  integrity sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==
+
+esbuild-linux-ppc64le@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz#dc3a3da321222b11e96e50efafec9d2de408198b"
+  integrity sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==
+
+esbuild-linux-riscv64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz#9bd6dcd3dca6c0357084ecd06e1d2d4bf105335f"
+  integrity sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==
+
+esbuild-linux-s390x@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz#a458af939b52f2cd32fc561410d441a51f69d41f"
+  integrity sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==
+
+esbuild-netbsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz#6388e785d7e7e4420cb01348d7483ab511b16aa8"
+  integrity sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==
+
+esbuild-openbsd-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz#309af806db561aa886c445344d1aacab850dbdc5"
+  integrity sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==
+
+esbuild-sunos-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz#3f19612dcdb89ba6c65283a7ff6e16f8afbf8aaa"
+  integrity sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==
+
+esbuild-windows-32@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz#a92d279c8458d5dc319abcfeb30aa49e8f2e6f7f"
+  integrity sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==
+
+esbuild-windows-64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz#2564c3fcf0c23d701edb71af8c52d3be4cec5f8a"
+  integrity sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==
+
+esbuild-windows-arm64@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz#86d9db1a22d83360f726ac5fba41c2f625db6878"
+  integrity sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==
+
+esbuild@0.14.47:
+  version "0.14.47"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.47.tgz#0d6415f6bd8eb9e73a58f7f9ae04c5276cda0e4d"
+  integrity sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==
+  optionalDependencies:
+    esbuild-android-64 "0.14.47"
+    esbuild-android-arm64 "0.14.47"
+    esbuild-darwin-64 "0.14.47"
+    esbuild-darwin-arm64 "0.14.47"
+    esbuild-freebsd-64 "0.14.47"
+    esbuild-freebsd-arm64 "0.14.47"
+    esbuild-linux-32 "0.14.47"
+    esbuild-linux-64 "0.14.47"
+    esbuild-linux-arm "0.14.47"
+    esbuild-linux-arm64 "0.14.47"
+    esbuild-linux-mips64le "0.14.47"
+    esbuild-linux-ppc64le "0.14.47"
+    esbuild-linux-riscv64 "0.14.47"
+    esbuild-linux-s390x "0.14.47"
+    esbuild-netbsd-64 "0.14.47"
+    esbuild-openbsd-64 "0.14.47"
+    esbuild-sunos-64 "0.14.47"
+    esbuild-windows-32 "0.14.47"
+    esbuild-windows-64 "0.14.47"
+    esbuild-windows-arm64 "0.14.47"
 
 esbuild@^0.24.0:
   version "0.24.0"
@@ -4022,7 +4650,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@^1.8.1:
+etag@1.8.1, etag@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
@@ -4031,6 +4659,11 @@ event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+events-intercept@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/events-intercept/-/events-intercept-2.0.0.tgz#adbf38681c5a4b2011c41ee41f61a34cba448897"
+  integrity sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==
 
 events@^3.3.0:
   version "3.3.0"
@@ -4097,6 +4730,17 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
+fast-glob@^3.2.7, fast-glob@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
 fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
@@ -4107,17 +4751,6 @@ fast-glob@^3.3.2:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
-
-fast-glob@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -4145,6 +4778,13 @@ fastq@^1.15.0, fastq@^1.6.0:
   integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
 
 fdir@^6.2.0:
   version "6.4.2"
@@ -4278,6 +4918,15 @@ fresh@^2.0.0:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
   integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
+fs-extra@11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
+  integrity sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -4317,6 +4966,11 @@ gcp-metadata@^7.0.0-rc.1:
     gaxios "^7.0.0-rc.1"
     google-logging-utils "^1.0.0"
     json-bigint "^1.0.0"
+
+generic-pool@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.4.2.tgz#92ff7196520d670839a67308092a12aadf2f6a59"
+  integrity sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -4540,7 +5194,7 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -4640,6 +5294,17 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+http-errors@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
+  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-errors@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
@@ -4650,6 +5315,14 @@ http-errors@^2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
+
+http-errors@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.4.0.tgz#6c0242dea6b3df7afda153c71089b31c6e82aabf"
+  integrity sha512-oLjPqve1tuOl5aRhv8GK5eHpqP1C9fb+Ol+XTLjKfLltE44zdDbEdjPSbU7Ch5rSNsVFqZn97SrMmZLdu1/YMw==
+  dependencies:
+    inherits "2.0.1"
+    statuses ">= 1.2.1 < 2"
 
 http-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -4695,6 +5368,13 @@ human-signals@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
+iconv-lite@0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ieee754@^1.2.1:
   version "1.2.1"
@@ -4750,6 +5430,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==
+
 inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
@@ -4791,6 +5476,11 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-builtin-module@^3.2.1:
   version "3.2.1"
@@ -4853,6 +5543,11 @@ is-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
   integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
 
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -4913,6 +5608,11 @@ is64bit@^2.0.0:
   dependencies:
     system-architecture "^0.1.0"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4965,6 +5665,11 @@ joi@^18.0.1:
     "@hapi/topo" "^6.0.2"
     "@standard-schema/spec" "^1.0.0"
 
+jose@5.9.6:
+  version "5.9.6"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.9.6.tgz#77f1f901d88ebdc405e57cce08d2a91f47521883"
+  integrity sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5014,6 +5719,14 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema-to-ts@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz#63e4fe854dff093923be9e8b59b39ee9a7971ba4"
+  integrity sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ts-toolbelt "^6.15.5"
+
 json-schema-to-typescript-lite@^14.1.0:
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/json-schema-to-typescript-lite/-/json-schema-to-typescript-lite-14.1.0.tgz#a35624a2d783e5e125631a3d25ac4c2fb96dd191"
@@ -5027,6 +5740,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -5036,6 +5754,15 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonfile@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.0.tgz#7c265bd1b65de6977478300087c99f1c84383f62"
+  integrity sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jwa@^2.0.0:
   version "2.0.1"
@@ -5243,6 +5970,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 magic-regexp@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/magic-regexp/-/magic-regexp-0.10.0.tgz#78b4421a50d2b7a67129bf2c424a333927c3a0e5"
@@ -5286,6 +6020,11 @@ magicast@^0.3.5:
     "@babel/types" "^7.25.4"
     source-map-js "^1.2.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
@@ -5311,6 +6050,15 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+micro@9.3.5-canary.3:
+  version "9.3.5-canary.3"
+  resolved "https://registry.yarnpkg.com/micro/-/micro-9.3.5-canary.3.tgz#e957598abb9ab05aea8453e0150a521fe22135c3"
+  integrity sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==
+  dependencies:
+    arg "4.1.0"
+    content-type "1.0.4"
+    raw-body "2.4.1"
+
 micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
@@ -5329,7 +6077,7 @@ mime-db@^1.54.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@^2.1.35:
+mime-types@2.1.35, mime-types@^2.1.12, mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5363,7 +6111,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -5422,7 +6170,7 @@ mitt@^3.0.1:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
-mkdirp@^1.0.3:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -5457,7 +6205,7 @@ mocked-exports@^0.1.1:
   resolved "https://registry.yarnpkg.com/mocked-exports/-/mocked-exports-0.1.1.tgz#6916efea9a9dd0f4abd6a0a72526f56a76c966ea"
   integrity sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==
 
-mri@^1.2.0:
+mri@1.2.0, mri@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
@@ -5466,6 +6214,16 @@ mrmime@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.0.tgz#151082a6e06e59a9a39b46b3e14d5cfe92b3abb4"
   integrity sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==
+
+ms@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
@@ -5611,6 +6369,20 @@ node-fetch-native@^1.6.6, node-fetch-native@^1.6.7:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.7.tgz#9d09ca63066cc48423211ed4caf5d70075d76a71"
   integrity sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==
+
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.7:
   version "2.7.0"
@@ -5837,6 +6609,13 @@ once@^1.4.0:
   dependencies:
     wrappy "1"
 
+once@~1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
+  integrity sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==
+  dependencies:
+    wrappy "1"
+
 onetime@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
@@ -5884,6 +6663,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+os-paths@^4.0.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/os-paths/-/os-paths-4.4.0.tgz#2908b5bcb60cbfe3afb869292281a2a6b2f77ebe"
+  integrity sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==
 
 oxc-minify@^0.86.0:
   version "0.86.0"
@@ -6045,6 +6829,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse-path@*:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.1.0.tgz#41fb513cb122831807a4c7b29c8727947a09d8c6"
@@ -6097,6 +6886,14 @@ path-key@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
   integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
+path-match@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/path-match/-/path-match-1.2.4.tgz#a62747f3c7e0c2514762697f24443585b09100ea"
+  integrity sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==
+  dependencies:
+    http-errors "~1.4.0"
+    path-to-regexp "^1.0.0"
+
 path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
@@ -6109,6 +6906,28 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+"path-to-regexp-updated@npm:path-to-regexp@6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+
+path-to-regexp@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
+
+path-to-regexp@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.3.0.tgz#aa818a6981f99321003a08987d3cec9c3474cd1f"
+  integrity sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==
+
+path-to-regexp@^1.0.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^5.0.0:
   version "5.0.0"
@@ -6130,6 +6949,11 @@ pathe@^2.0.1, pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 perfect-debounce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/perfect-debounce/-/perfect-debounce-1.0.0.tgz#9c2e8bc30b169cc984a58b7d5b28049839591d2a"
@@ -6139,6 +6963,11 @@ perfect-debounce@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/perfect-debounce/-/perfect-debounce-2.0.0.tgz#0ff94f1ecbe0a6bca4b1703a2ed08bbe43739aa7"
   integrity sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==
+
+picocolors@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picocolors@^1, picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
@@ -6488,6 +7317,13 @@ pretty-bytes@^7.0.1:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-7.0.1.tgz#24100e03ff1cd911900bf0149183e49e58a737d8"
   integrity sha512-285/jRCYIbMGDciDdrw0KPNC4LKEEwz/bwErcYNxSJOi4CpGUuLpb9gQpg3XJP0XYj9ldSRluXxih4lX2YN8Xw==
 
+pretty-ms@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
+  integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
+  dependencies:
+    parse-ms "^2.1.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -6497,6 +7333,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
+promisepipe@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/promisepipe/-/promisepipe-3.0.0.tgz#c9b6e5aa861ef5fcce6134f6f75e14f8f30bd3b2"
+  integrity sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==
 
 prompts@^2.4.2:
   version "2.4.2"
@@ -6577,6 +7418,16 @@ range-parser@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
+  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.3"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 rc9@^2.1.2:
   version "2.1.2"
@@ -6708,6 +7559,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -6741,6 +7597,11 @@ retry-request@^8.0.0:
     extend "^3.0.2"
     teeny-request "^10.0.0"
 
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -6757,6 +7618,31 @@ rimraf@^5.0.5:
   integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
   dependencies:
     glob "^10.3.7"
+
+rolldown@1.0.0-beta.35:
+  version "1.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.0-beta.35.tgz#2ef3944d9eb575a5c665f36013c42e1634eb83c6"
+  integrity sha512-gJATyqcsJe0Cs8RMFO8XgFjfTc0lK1jcSvirDQDSIfsJE+vt53QH/Ob+OBSJsXb98YtZXHfP/bHpELpPwCprow==
+  dependencies:
+    "@oxc-project/runtime" "=0.82.3"
+    "@oxc-project/types" "=0.82.3"
+    "@rolldown/pluginutils" "1.0.0-beta.35"
+    ansis "^4.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.0.0-beta.35"
+    "@rolldown/binding-darwin-arm64" "1.0.0-beta.35"
+    "@rolldown/binding-darwin-x64" "1.0.0-beta.35"
+    "@rolldown/binding-freebsd-x64" "1.0.0-beta.35"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.0.0-beta.35"
+    "@rolldown/binding-linux-arm64-gnu" "1.0.0-beta.35"
+    "@rolldown/binding-linux-arm64-musl" "1.0.0-beta.35"
+    "@rolldown/binding-linux-x64-gnu" "1.0.0-beta.35"
+    "@rolldown/binding-linux-x64-musl" "1.0.0-beta.35"
+    "@rolldown/binding-openharmony-arm64" "1.0.0-beta.35"
+    "@rolldown/binding-wasm32-wasi" "1.0.0-beta.35"
+    "@rolldown/binding-win32-arm64-msvc" "1.0.0-beta.35"
+    "@rolldown/binding-win32-ia32-msvc" "1.0.0-beta.35"
+    "@rolldown/binding-win32-x64-msvc" "1.0.0-beta.35"
 
 rollup-plugin-visualizer@^6.0.3:
   version "6.0.3"
@@ -6820,6 +7706,11 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 sax@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
@@ -6844,10 +7735,17 @@ scule@^1.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@^6.3.1:
+semver@6.3.1, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@^7.3.6, semver@^7.5.3, semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
@@ -6900,6 +7798,11 @@ serve-static@^2.2.0:
     parseurl "^1.3.3"
     send "^1.2.0"
 
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
@@ -6921,6 +7824,11 @@ shell-quote@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+
+signal-exit@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.0.2.tgz#ff55bb1d9ff2114c13b400688fa544ac63c36967"
+  integrity sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==
 
 signal-exit@^3.0.7:
   version "3.0.7"
@@ -7047,10 +7955,20 @@ standard-as-callback@^2.1.0:
   resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
+stat-mode@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-0.3.0.tgz#69283b081f851582b328d2a4ace5f591ce52f54b"
+  integrity sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+"statuses@>= 1.2.1 < 2", "statuses@>= 1.5.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
 statuses@^2.0.1:
   version "2.0.2"
@@ -7078,6 +7996,22 @@ stream-shift@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
   integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
+
+stream-to-array@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/stream-to-array/-/stream-to-array-2.3.0.tgz#bbf6b39f5f43ec30bc71babcb37557acecf34353"
+  integrity sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==
+  dependencies:
+    any-promise "^1.1.0"
+
+stream-to-promise@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stream-to-promise/-/stream-to-promise-2.2.0.tgz#b1edb2e1c8cb11289d1b503c08d3f2aef51e650f"
+  integrity sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==
+  dependencies:
+    any-promise "~1.3.0"
+    end-of-stream "~1.1.0"
+    stream-to-array "~2.3.0"
 
 streamx@^2.15.0:
   version "2.21.1"
@@ -7306,7 +8240,7 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@^6.2.0:
+tar@6.2.1, tar@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
@@ -7371,10 +8305,27 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+throttleit@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
+  integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
+
+time-span@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/time-span/-/time-span-4.0.0.tgz#fe74cd50a54e7998712f90ddfe47109040c985c4"
+  integrity sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==
+  dependencies:
+    convert-hrtime "^3.0.0"
+
 tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tinyexec@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
 tinyexec@^0.3.1:
   version "0.3.1"
@@ -7409,6 +8360,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
+  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
@@ -7424,6 +8380,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+tree-kill@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 ts-api-utils@^1.3.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
@@ -7433,6 +8394,38 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+ts-morph@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-12.0.0.tgz#a601c3538703755cbfa2d42b62c52df73e9dbbd7"
+  integrity sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==
+  dependencies:
+    "@ts-morph/common" "~0.11.0"
+    code-block-writer "^10.1.1"
+
+ts-node@10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
+ts-toolbelt@^6.15.5:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
+  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
 
 tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3:
   version "2.8.1"
@@ -7471,6 +8464,11 @@ type-level-regexp@~0.1.17:
   resolved "https://registry.yarnpkg.com/type-level-regexp/-/type-level-regexp-0.1.17.tgz#ec1bf7dd65b85201f9863031d6f023bdefc2410f"
   integrity sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==
 
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
 typescript@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
@@ -7485,6 +8483,11 @@ ufo@^1.1.2, ufo@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.5.4.tgz#16d6949674ca0c9e0fbbae1fa20a71d7b1ded754"
   integrity sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==
+
+uid-promise@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/uid-promise/-/uid-promise-1.0.0.tgz#68ef7c70a19dea4d637c7e3df2e0e548106f1a37"
+  integrity sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==
 
 ultrahtml@^1.6.0:
   version "1.6.0"
@@ -7525,6 +8528,20 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@5.28.4:
+  version "5.28.4"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
+  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
+
+undici@^5.28.4:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 unenv@2.0.0-rc.20:
   version "2.0.0-rc.20"
@@ -7615,6 +8632,16 @@ unimport@^5.2.0:
     tinyglobby "^0.2.14"
     unplugin "^2.3.5"
     unplugin-utils "^0.2.4"
+
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
+unpipe@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
 unplugin-utils@^0.2.4:
   version "0.2.5"
@@ -7777,6 +8804,11 @@ uuid@^11.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -7784,6 +8816,30 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vercel@^48.1.6:
+  version "48.1.6"
+  resolved "https://registry.yarnpkg.com/vercel/-/vercel-48.1.6.tgz#06184fc929b1c46c281a4c1378c0ab5b839fda96"
+  integrity sha512-bcfocpaHfG0FHpTdY59Pfgm26cznI7+9KhGAnVkv4pU+oM6Ggc+w/nnsjuS5EY+/v3vI3f8cYamE6DDqQ3CpEQ==
+  dependencies:
+    "@vercel/blob" "1.0.2"
+    "@vercel/build-utils" "12.1.0"
+    "@vercel/detect-agent" "1.0.0"
+    "@vercel/express" "0.0.22"
+    "@vercel/fun" "1.1.6"
+    "@vercel/go" "3.2.3"
+    "@vercel/h3" "0.1.2"
+    "@vercel/hono" "0.1.2"
+    "@vercel/hydrogen" "1.2.4"
+    "@vercel/next" "4.13.0"
+    "@vercel/node" "5.3.24"
+    "@vercel/python" "5.0.5"
+    "@vercel/redwood" "2.3.6"
+    "@vercel/remix-builder" "5.4.12"
+    "@vercel/ruby" "2.2.1"
+    "@vercel/static-build" "2.7.23"
+    chokidar "4.0.0"
+    jose "5.9.6"
 
 vite-dev-rpc@^1.1.0:
   version "1.1.0"
@@ -7935,6 +8991,11 @@ web-streams-polyfill@^3.0.3:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
+web-vitals@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -8021,6 +9082,20 @@ wsl-utils@^0.1.0:
   dependencies:
     is-wsl "^3.1.0"
 
+xdg-app-paths@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz#f52f724f91e88244148c085c09bcd396443d8cae"
+  integrity sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==
+  dependencies:
+    xdg-portable "^7.0.0"
+
+xdg-portable@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/xdg-portable/-/xdg-portable-7.3.0.tgz#c6b1610de806a2ca1fe65727d5f8402c295d2e96"
+  integrity sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==
+  dependencies:
+    os-paths "^4.0.1"
+
 xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
@@ -8074,6 +9149,34 @@ yargs@^17.5.1, yargs@^17.7.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
+yauzl-clone@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/yauzl-clone/-/yauzl-clone-1.0.4.tgz#8bc6d293b17cc98802bbbed2e289d18e7697c96c"
+  integrity sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==
+  dependencies:
+    events-intercept "^2.0.0"
+
+yauzl-promise@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/yauzl-promise/-/yauzl-promise-2.1.3.tgz#17467845db89fc6592ca987ca2ecfee8c381ae3d"
+  integrity sha512-A1pf6fzh6eYkK0L4Qp7g9jzJSDrM6nN0bOn5T0IbY4Yo3w+YkWlHFkJP7mzknMXjqusHFHlKsK2N+4OLsK2MRA==
+  dependencies:
+    yauzl "^2.9.1"
+    yauzl-clone "^1.0.4"
+
+yauzl@^2.9.1:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
@@ -8122,3 +9225,8 @@ zip-stream@^6.0.1:
     archiver-utils "^5.0.0"
     compress-commons "^6.0.2"
     readable-stream "^4.0.0"
+
+zod@3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
- **feat(API types): add report types**
- **feat(API types): add final report types**
- **feat(Composables): add composables to activate and deactivate vacancies**
- **feat(Composables): add composables to activate and deactivate students**
- **feat(Composables): add `useFetchFinalReports`**
- **feat(Composables): add `usePatchFinalReport`**
- **feat(Composables): add `useFetchReports`**
- **feat(Composables): add `usePatchReport`**
- **feat(Organisms): add `FinalReportsTable`**
- **feat(Organisms): add `ReportsTable`**
- **feat(Student API types): add `deletedAt` prop**
- **feat(Vacancy API types): add `deletedAt` prop**
- **refactor(Comission office API types): change `UpdateComissionOffice`**
- **feat(ComissionOfficesTable): remove delete button**
- **fix(Composables): fix fetch keys**
- **feat(Navbar): remove `Administrativo` link**
- **feat(Login store): update url to login as student**
- **feat(Vacancy page): add reports tabs content**
- **feat(Student page): add reports tabs content**
- **fix(Department page): remove delete button**
- **refactor: change `estudiante` by `alumno`**
- **fix: build error**
- **feat(Packages): add vercel**
